### PR TITLE
feat: retry fetching m3u8 URL with exponential backoff

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,9 +1,22 @@
 package main
 
 const (
-	DatetimeLayout       = "20060102150405"
+	// DatetimeLayout for time strings from radiko
+	DatetimeLayout = "20060102150405"
+	// DefaultArea for radiko are
+	DefaultArea = "JP13"
+	// MaxRetryAttempts for BackOffDelay
+	MaxRetryAttempts = 8
+	// RetryDelaySecond for initial delay
+	RetryDelaySecond = 60
+	// DefaultInterval to fetch the programs
+	DefaultInterval = "168h"
+	// OutputDatetimeLayout for downloaded files
 	OutputDatetimeLayout = "200601021504"
-	MaxConcurrents       = 64
-	MaxAttempts          = 4
-	TZTokyo              = "Asia/Tokyo"
+	// MaxConcurrents for doenloading programs
+	MaxConcurrents = 64
+	// MaxAttempts for downloading programs
+	MaxAttempts = 4
+	// TZTokyo for time location
+	TZTokyo = "Asia/Tokyo"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/iomz/radicron
 go 1.20
 
 require (
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bogem/id3v2 v1.2.0
 	github.com/go-co-op/gocron v1.27.1
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/Masterminds/sprig/v3 v3.2.0 h1:P1ekkbuU73Ui/wS0nK1HOM37hh4xdfZo485UPf
 github.com/Masterminds/sprig/v3 v3.2.0/go.mod h1:tWhwTbUTndesPNeF0C900vKoq283u6zp4APT9vaF3SI=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bogem/id3v2 v1.2.0 h1:hKDF+F1gOgQ5r1QmBCEZUk4MveJbKxCeIDSBU7CQ4oI=

--- a/main.go
+++ b/main.go
@@ -130,9 +130,9 @@ func main() {
 	}
 
 	// set the default area_id
-	viper.SetDefault("area-id", "JP13")
+	viper.SetDefault("area-id", DefaultArea)
 	// set the default interval as weekly
-	viper.SetDefault("interval", "168h")
+	viper.SetDefault("interval", DefaultInterval)
 	// set the default file-format as aac
 	viper.SetDefault("file-format", radigo.AudioFormatAAC)
 
@@ -141,10 +141,17 @@ func main() {
 	fileFormat = viper.GetString("file-format")
 	interval = viper.GetString("interval")
 
-	// TODO: validate the config parameters
+	// TODO: verify the area-id
+	// check if the interval is invalid or is too short
+	intervalDuration, err := time.ParseDuration(interval)
+	if err != nil || intervalDuration < time.Hour {
+		log.Fatalf("invalid interval: %s, setting to %v", interval, DefaultInterval)
+		interval = DefaultInterval
+	}
+	// check the output file format
 	if fileFormat != radigo.AudioFormatAAC &&
 		fileFormat != radigo.AudioFormatMP3 {
-		log.Fatalf("Unsupported audio format: %s", fileFormat)
+		log.Fatalf("unsupported audio format: %s", fileFormat)
 	}
 
 	log.Printf("[config] area-id: %s", areaID)


### PR DESCRIPTION
Sometimes the EXT m3u8 URLs take a bit longer after the show is finished.
Wait for some time and retry fetching the URL safely.

Also adding `window` field to the rule for specifying the fetching time window counting from the time of fetching.