### PR TITLE
feat(download): handle cross-filesystem moves and improve code quality

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,42 @@
+# Cursor AI Preferences for this Project
+
+## Commit Message Format
+
+All Git commit messages must follow the [Conventional Changelog](https://github.com/conventional-changelog/conventional-changelog) format:
+
+```text
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+Where:
+
+- **type**: The type of change (feat, fix, docs, style, refactor, perf, test, chore, etc.)
+- **scope**: Optional - the area of the codebase affected (e.g., ui, core, handlers)
+- **subject**: Short description in imperative mood (e.g., "add feature" not "added feature")
+- **body**: Optional - detailed explanation of the change
+- **footer**: Optional - references to issues, breaking changes, etc.
+
+Example:
+
+```text
+feat(ui): add dark mode toggle
+
+Implement dark mode support with toggle in settings panel.
+Uses system preferences as default.
+
+Closes #123
+```
+
+## Commit Behavior
+
+- **DO NOT** automatically commit changes
+- Always let the user review changes first before committing
+- Only commit when explicitly requested by the user
+- When committing, use the Conventional Changelog format described above
+- **ALWAYS** run gofmt whenever making changes to a Go file
+- **ALWAYS** check golangci-lint before committing a change
+

--- a/const.go
+++ b/const.go
@@ -33,6 +33,10 @@ const (
 	TZTokyo = "Asia/Tokyo"
 	// UserIDLength for user-id
 	UserIDLength = 16
+	// PlaylistM3U8Length parameter for m3u8 playlist requests
+	PlaylistM3U8Length = "15"
+	// DirPermissions for directory creation (0755 = rwxr-xr-x)
+	DirPermissions = 0755
 
 	// API endpoints
 	// region full

--- a/program.go
+++ b/program.go
@@ -126,6 +126,6 @@ func decodeWeeklyProgram(iorc io.ReadCloser) (Progs, error) {
 		return progs, err
 	}
 
-	err = xml.Unmarshal([]byte(string(body)), &progs)
+	err = xml.Unmarshal(body, &progs)
 	return progs, err
 }


### PR DESCRIPTION
## Summary

This PR adds support for cross-filesystem file moves and improves overall code quality through refactoring.

## Changes

### Core Features
- **Cross-filesystem move support**: Added `moveFile` helper that attempts `os.Rename` first and falls back to copy-then-delete for cross-filesystem moves
- **Fixed logging bug**: Fixed issue where log referenced moved object's method after deletion

### Code Quality Improvements
- **Error wrapping**: Replaced `%s` with `%w` for proper error context in 7 locations
- **Bug fix**: Fixed error message using incorrect variable (prog.To instead of start)
- **Code simplification**: Removed redundant type conversion in `decodeWeeklyProgram`
- **DRY principle**: Extracted duplicate OutputConfig creation to helper function
- **Constants**: Extracted magic strings to constants (`PlaylistM3U8Length`, `DirPermissions`)

### Test Improvements
- **Reduced complexity**: Split monolithic `TestHandleDuplicate` into 5 separate test functions
- **Test organization**: Created `setupHandleDuplicateTest` helper for common setup
- **Fixed linter issues**: Resolved cyclomatic complexity and unused parameter warnings

## Commits
- `54e49b7` fix(download): handle cross-filesystem moves with fallback
- `652804a` refactor(download): improve code quality and error handling
- `ba82673` refactor(test): reduce cyclomatic complexity in TestHandleDuplicate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with better context in error messages
  * Enhanced duplicate file handling with capability to move files to configured folders

* **Tests**
  * Added comprehensive test coverage for duplicate file scenarios

* **Chores**
  * Added commit message conventions and workflow guidelines

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->