### PR TITLE
fix(gui): prevent monitoring hang when no rules or rules without criteria

### DIFF
--- a/cmd/radikron-gui/app.go
+++ b/cmd/radikron-gui/app.go
@@ -769,8 +769,13 @@ func (a *App) sleepUntilNextFetch(ctx context.Context) {
 			}
 		}
 	} else {
-		// Default sleep if no next fetch time
-		time.Sleep(1 * time.Hour)
+		// Default sleep if no next fetch time - use timer with context cancellation
+		timer := time.NewTimer(1 * time.Hour)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
 	}
 }
 
@@ -840,6 +845,18 @@ func (a *App) runMonitoringLoop(ctx context.Context) {
 
 		// Check if rules are configured
 		a.checkAndLogRulesCount(asset)
+
+		// Skip processing if no rules or all rules have no criteria
+		if len(asset.Rules) == 0 || !asset.Rules.HasRuleWithCriteria() {
+			log.Printf("skipping program collection: no rules with criteria configured")
+			runtime.EventsEmit(a.ctx, "log-message", map[string]any{
+				"type":    "warning",
+				"message": "No rules with criteria configured - skipping program collection",
+			})
+			// Sleep until next fetch time
+			a.logAndSleepUntilNextFetch(asset, ctx)
+			continue
+		}
 
 		// Collect and process programs
 		a.processAllPrograms(asset, fetcher, downloadCtx, downloader)

--- a/rule.go
+++ b/rule.go
@@ -56,6 +56,16 @@ func (rs Rules) HasRuleForStationID(stationID string) bool {
 	return false
 }
 
+// HasRuleWithCriteria returns true if at least one rule has optional criteria (Title, Pfm, or Keyword)
+func (rs Rules) HasRuleWithCriteria() bool {
+	for _, r := range rs {
+		if r.HasTitle() || r.HasPfm() || r.HasKeyword() {
+			return true
+		}
+	}
+	return false
+}
+
 type Rule struct {
 	Name      string   `mapstructure:"name"`       // required
 	Title     string   `mapstructure:"title"`      // required if pfm and keyword are unset

--- a/rule_test.go
+++ b/rule_test.go
@@ -922,3 +922,90 @@ func TestMatchSilent(t *testing.T) {
 		t.Error("MatchSilent should return false for rule with no criteria")
 	}
 }
+
+func TestHasRuleWithCriteria(t *testing.T) {
+	var hrwctests = []struct {
+		in  Rules
+		out bool
+	}{
+		{
+			// Empty rules
+			Rules{},
+			false,
+		},
+		{
+			// Rule with Title only
+			Rules{
+				&Rule{"test", "Title", []string{}, "", "", "FMT", "", ""},
+			},
+			true,
+		},
+		{
+			// Rule with Pfm only
+			Rules{
+				&Rule{"test", "", []string{}, "", "Pfm", "FMT", "", ""},
+			},
+			true,
+		},
+		{
+			// Rule with Keyword only
+			Rules{
+				&Rule{"test", "", []string{}, "Keyword", "", "FMT", "", ""},
+			},
+			true,
+		},
+		{
+			// Rule with Title and Pfm
+			Rules{
+				&Rule{"test", "Title", []string{}, "", "Pfm", "FMT", "", ""},
+			},
+			true,
+		},
+		{
+			// Rule with all criteria
+			Rules{
+				&Rule{"test", "Title", []string{}, "Keyword", "Pfm", "FMT", "", ""},
+			},
+			true,
+		},
+		{
+			// Rule with no criteria
+			Rules{
+				&Rule{"test", "", []string{}, "", "", "FMT", "", ""},
+			},
+			false,
+		},
+		{
+			// Multiple rules, all without criteria
+			Rules{
+				&Rule{"test1", "", []string{}, "", "", "FMT", "", ""},
+				&Rule{"test2", "", []string{}, "", "", "TBS", "", ""},
+			},
+			false,
+		},
+		{
+			// Multiple rules, some with criteria
+			Rules{
+				&Rule{"test1", "", []string{}, "", "", "FMT", "", ""},
+				&Rule{"test2", "Title", []string{}, "", "", "TBS", "", ""},
+			},
+			true,
+		},
+		{
+			// Multiple rules, all with criteria
+			Rules{
+				&Rule{"test1", "Title1", []string{}, "", "", "FMT", "", ""},
+				&Rule{"test2", "", []string{}, "Keyword", "", "TBS", "", ""},
+				&Rule{"test3", "", []string{}, "", "Pfm", "MBS", "", ""},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range hrwctests {
+		res := tt.in.HasRuleWithCriteria()
+		if tt.out != res {
+			t.Errorf("(%v).HasRuleWithCriteria() => %v, want %v", tt.in, res, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #54

This PR fixes the issue where starting monitoring with no rules or rules without criteria would cause the application to hang.

## Changes

- Replace blocking `time.Sleep` with context-aware timer in `sleepUntilNextFetch` to allow immediate cancellation when stopping monitoring
- Add `HasRuleWithCriteria` helper function to check if any rules have optional criteria (Title, Pfm, or Keyword)
- Skip program collection when no rules or all rules have no criteria to avoid unnecessary network calls
- Add comprehensive test coverage for `HasRuleWithCriteria` function

## Testing

- All existing tests pass
- New test for `HasRuleWithCriteria` covers all edge cases
- Verified that monitoring can now be stopped immediately without hanging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect when no monitoring rules or rule criteria are configured, with appropriate warning messages logged.

* **Bug Fixes**
  * Improved sleep behavior to respect context cancellation, enabling more responsive shutdown of idle states.

* **Tests**
  * Added comprehensive test coverage for rule validation logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->