### PR TITLE
fix(config): preserve rule order when saving and loading config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Create flexible rules to automatically capture your favorite programs using mult
 
 - **Custom Download Directories**: Configure where your files are saved
 - **Rule-Based Folders**: Automatically organize downloads into subfolders based on matching rules
+- **Rule Order Precedence**: When a program matches multiple rules, the first matching rule (by order in config) determines the destination folder
 - **Configurable File Formats**: Choose between AAC (default) or MP3 output formats
 
 ### 🏷️ Automatic ID3 Tagging
@@ -193,6 +194,8 @@ Each rule can use one or more of the following matching criteria (all support pa
 - **`folder`**: (Optional) Organize downloads for this rule into a subfolder
 
 Rules are evaluated with AND logic - a program must match all specified criteria in a rule.
+
+**Important**: Rule order matters! When a program matches multiple rules, the first matching rule (in the order they appear in your config file) determines which folder the file is saved to. This allows you to prioritize certain rules by placing them earlier in your configuration.
 
 ### Example Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -182,6 +182,8 @@ type configYAML struct {
 	MaxDownloadingConcurrency *int                 `yaml:"max-downloading-concurrency,omitempty"`
 	MaxEncodingConcurrency    *int                 `yaml:"max-encoding-concurrency,omitempty"`
 	Rules                     map[string]*ruleYAML `yaml:"rules,omitempty"`
+	// rulesOrder stores the order of rule names for custom marshaling
+	rulesOrder []string
 }
 
 // ruleYAML represents a rule in YAML format
@@ -195,12 +197,14 @@ type ruleYAML struct {
 	Folder    string   `yaml:"folder,omitempty"`
 }
 
-// convertRulesToYAML converts rules to YAML format
-func convertRulesToYAML(rules radikron.Rules) map[string]*ruleYAML {
+// convertRulesToYAML converts rules to YAML format, preserving order
+// Returns both the map and the order of rule names
+func convertRulesToYAML(rules radikron.Rules) (rulesMap map[string]*ruleYAML, order []string) {
 	if len(rules) == 0 {
-		return nil
+		return nil, nil
 	}
-	result := make(map[string]*ruleYAML)
+	rulesMap = make(map[string]*ruleYAML, len(rules))
+	order = make([]string, 0, len(rules))
 	for _, rule := range rules {
 		ruleYAMLObj := &ruleYAML{
 			Folder: rule.Folder,
@@ -223,9 +227,10 @@ func convertRulesToYAML(rules radikron.Rules) map[string]*ruleYAML {
 		if rule.HasWindow() {
 			ruleYAMLObj.Window = rule.Window
 		}
-		result[rule.Name] = ruleYAMLObj
+		rulesMap[rule.Name] = ruleYAMLObj
+		order = append(order, rule.Name)
 	}
-	return result
+	return rulesMap, order
 }
 
 // SaveConfig saves the configuration to a file in YAML format
@@ -260,11 +265,11 @@ func (c *Config) SaveConfig(filename string) error {
 		cfgYAML.MaxEncodingConcurrency = &c.MaxEncodingConcurrency
 	}
 
-	// Convert rules to YAML format
-	cfgYAML.Rules = convertRulesToYAML(c.Rules)
+	// Convert rules to YAML format, preserving order
+	cfgYAML.Rules, cfgYAML.rulesOrder = convertRulesToYAML(c.Rules)
 
-	// Marshal to YAML
-	data, err := yaml.Marshal(&cfgYAML)
+	// Marshal to YAML using custom marshaler to preserve order
+	data, err := marshalConfigWithOrder(&cfgYAML)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
@@ -279,6 +284,98 @@ func (c *Config) SaveConfig(filename string) error {
 		return fmt.Errorf("failed to rename config file: %w", err)
 	}
 	return nil
+}
+
+// marshalConfigWithOrder marshals config to YAML while preserving the order of rules
+func marshalConfigWithOrder(cfg *configYAML) ([]byte, error) {
+	// First, marshal the config without rules to get the base structure
+	cfgWithoutRules := *cfg
+	cfgWithoutRules.Rules = nil
+	cfgWithoutRules.rulesOrder = nil
+
+	baseData, err := yaml.Marshal(&cfgWithoutRules)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the base YAML to get a node structure
+	var baseNode yaml.Node
+	if err := yaml.Unmarshal(baseData, &baseNode); err != nil {
+		return nil, fmt.Errorf("failed to parse base YAML: %w", err)
+	}
+
+	// Find the root mapping node
+	var rootMapping *yaml.Node
+	if baseNode.Kind == yaml.DocumentNode && len(baseNode.Content) > 0 {
+		rootMapping = baseNode.Content[0]
+	} else {
+		rootMapping = &baseNode
+	}
+
+	if rootMapping.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("expected mapping node")
+	}
+
+	// Add rules section with preserved order
+	if len(cfg.Rules) > 0 {
+		// Create key node for "rules"
+		rulesKeyNode := &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: "rules",
+		}
+
+		// Create mapping node for rules
+		rulesMappingNode := &yaml.Node{
+			Kind: yaml.MappingNode,
+		}
+
+		// Add rules in order
+		for _, ruleName := range cfg.rulesOrder {
+			rule, exists := cfg.Rules[ruleName]
+			if !exists {
+				continue
+			}
+
+			// Create key node for rule name
+			ruleKeyNode := &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: ruleName,
+			}
+
+			// Marshal rule to get its node structure
+			ruleData, err := yaml.Marshal(rule)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal rule %s: %w", ruleName, err)
+			}
+
+			var ruleDocNode yaml.Node
+			if err := yaml.Unmarshal(ruleData, &ruleDocNode); err != nil {
+				return nil, fmt.Errorf("failed to parse rule %s: %w", ruleName, err)
+			}
+
+			// Get the mapping node from the rule document
+			var ruleMapping *yaml.Node
+			if ruleDocNode.Kind == yaml.DocumentNode && len(ruleDocNode.Content) > 0 {
+				ruleMapping = ruleDocNode.Content[0]
+			} else {
+				ruleMapping = &ruleDocNode
+			}
+
+			// Ensure it's a mapping node
+			if ruleMapping.Kind != yaml.MappingNode {
+				return nil, fmt.Errorf("expected mapping node for rule %s", ruleName)
+			}
+
+			// Add key-value pair to rules mapping
+			rulesMappingNode.Content = append(rulesMappingNode.Content, ruleKeyNode, ruleMapping)
+		}
+
+		// Add rules key-value pair to root mapping
+		rootMapping.Content = append(rootMapping.Content, rulesKeyNode, rulesMappingNode)
+	}
+
+	// Marshal the complete node structure
+	return yaml.Marshal(&baseNode)
 }
 
 // findRulesNode finds the "rules" mapping node in the YAML document.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -516,6 +516,19 @@ func TestSaveConfig(t *testing.T) {
 	if len(savedCfg.Rules) != len(cfg.Rules) {
 		t.Errorf("expected %d rules, got %d", len(cfg.Rules), len(savedCfg.Rules))
 	}
+
+	// Verify rule order is preserved
+	if len(cfg.Rules) > 0 {
+		for i, originalRule := range cfg.Rules {
+			if i >= len(savedCfg.Rules) {
+				t.Fatalf("saved config has fewer rules than original")
+			}
+			if savedCfg.Rules[i].Name != originalRule.Name {
+				t.Errorf("rule order not preserved at index %d: expected %s, got %s",
+					i, originalRule.Name, savedCfg.Rules[i].Name)
+			}
+		}
+	}
 }
 
 func TestSaveConfigWithCustomConcurrency(t *testing.T) {
@@ -623,9 +636,12 @@ func TestSaveConfigWithDefaultConcurrency(t *testing.T) {
 func TestConvertRulesToYAML(t *testing.T) {
 	// Test with empty rules
 	rules := radikron.Rules{}
-	result := convertRulesToYAML(rules)
+	result, order := convertRulesToYAML(rules)
 	if result != nil {
 		t.Errorf("expected nil for empty rules, got %v", result)
+	}
+	if order != nil {
+		t.Errorf("expected nil order for empty rules, got %v", order)
 	}
 
 	// Test with rules containing all fields
@@ -641,9 +657,12 @@ func TestConvertRulesToYAML(t *testing.T) {
 	}
 
 	rules = radikron.Rules{rule}
-	result = convertRulesToYAML(rules)
+	result, order = convertRulesToYAML(rules)
 	if result == nil {
 		t.Fatal("expected non-nil result for rules with fields")
+	}
+	if len(order) != 1 || order[0] != "test-rule" {
+		t.Errorf("expected order to contain 'test-rule', got %v", order)
 	}
 
 	ruleYAML, ok := result["test-rule"]
@@ -683,9 +702,12 @@ func TestConvertRulesToYAMLPartialFields(t *testing.T) {
 	}
 
 	rules := radikron.Rules{rule}
-	result := convertRulesToYAML(rules)
+	result, order := convertRulesToYAML(rules)
 	if result == nil {
 		t.Fatal("expected non-nil result")
+	}
+	if len(order) != 1 || order[0] != "partial-rule" {
+		t.Errorf("expected order to contain 'partial-rule', got %v", order)
 	}
 
 	ruleYAML, ok := result["partial-rule"]
@@ -926,6 +948,68 @@ rules:
 		_, err = loadRules()
 		if err == nil {
 			t.Error("expected error with malformed rule")
+		}
+	}
+}
+
+func TestSaveConfigPreservesRuleOrder(t *testing.T) {
+	// Create a temporary directory
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "order-test-config.yml")
+
+	// Create a config with multiple rules in a specific order
+	cfg := &Config{
+		AreaID:     "JP13",
+		FileFormat: radigo.AudioFormatAAC,
+		Rules: radikron.Rules{
+			&radikron.Rule{Name: "first-rule", StationID: "FMT", Title: "First"},
+			&radikron.Rule{Name: "second-rule", StationID: "TBS", Title: "Second"},
+			&radikron.Rule{Name: "third-rule", StationID: "MBS", Title: "Third"},
+			&radikron.Rule{Name: "fourth-rule", StationID: "FMJ", Title: "Fourth"},
+		},
+	}
+
+	// Save the config
+	err := cfg.SaveConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error saving config, got: %v", err)
+	}
+
+	// Load the saved config
+	savedCfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error loading saved config, got: %v", err)
+	}
+
+	// Verify the order is preserved
+	expectedOrder := []string{"first-rule", "second-rule", "third-rule", "fourth-rule"}
+	if len(savedCfg.Rules) != len(expectedOrder) {
+		t.Fatalf("expected %d rules, got %d", len(expectedOrder), len(savedCfg.Rules))
+	}
+
+	for i, expectedName := range expectedOrder {
+		if savedCfg.Rules[i].Name != expectedName {
+			t.Errorf("rule order not preserved at index %d: expected %s, got %s",
+				i, expectedName, savedCfg.Rules[i].Name)
+		}
+	}
+
+	// Verify the rules can be saved and loaded multiple times while preserving order
+	err = savedCfg.SaveConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error saving config again, got: %v", err)
+	}
+
+	reloadedCfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error reloading config, got: %v", err)
+	}
+
+	// Verify order is still preserved after multiple save/load cycles
+	for i, expectedName := range expectedOrder {
+		if reloadedCfg.Rules[i].Name != expectedName {
+			t.Errorf("rule order not preserved after multiple save/load cycles at index %d: expected %s, got %s",
+				i, expectedName, reloadedCfg.Rules[i].Name)
 		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1013,3 +1013,345 @@ func TestSaveConfigPreservesRuleOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestMarshalConfigWithOrder_NoRules(t *testing.T) {
+	// Test marshaling config with no rules
+	cfg := &configYAML{
+		AreaID:     "JP13",
+		FileFormat: "aac",
+		Rules:      nil,
+		rulesOrder: nil,
+	}
+
+	data, err := marshalConfigWithOrder(cfg)
+	if err != nil {
+		t.Fatalf("expected no error marshaling config with no rules, got: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty YAML data")
+	}
+
+	// Verify it can be unmarshaled
+	var result configYAML
+	if err := yaml.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if result.AreaID != "JP13" {
+		t.Errorf("expected AreaID to be JP13, got %s", result.AreaID)
+	}
+}
+
+func TestMarshalConfigWithOrder_EmptyRules(t *testing.T) {
+	// Test marshaling config with empty rules map
+	cfg := &configYAML{
+		AreaID:     "JP13",
+		FileFormat: "aac",
+		Rules:      make(map[string]*ruleYAML),
+		rulesOrder: []string{},
+	}
+
+	data, err := marshalConfigWithOrder(cfg)
+	if err != nil {
+		t.Fatalf("expected no error marshaling config with empty rules, got: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty YAML data")
+	}
+}
+
+func TestMarshalConfigWithOrder_MissingRuleInMap(t *testing.T) {
+	// Test case where rulesOrder contains a name that doesn't exist in Rules map
+	cfg := &configYAML{
+		AreaID:     "JP13",
+		FileFormat: "aac",
+		Rules: map[string]*ruleYAML{
+			"existing-rule": {
+				StationID: "FMT",
+				Title:     "Test",
+			},
+		},
+		rulesOrder: []string{"existing-rule", "missing-rule"},
+	}
+
+	data, err := marshalConfigWithOrder(cfg)
+	if err != nil {
+		t.Fatalf("expected no error when rule is missing from map, got: %v", err)
+	}
+
+	// Verify only existing rule is in output
+	var result struct {
+		Rules map[string]*ruleYAML `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if _, exists := result.Rules["missing-rule"]; exists {
+		t.Error("missing rule should not appear in output")
+	}
+	if _, exists := result.Rules["existing-rule"]; !exists {
+		t.Error("existing rule should appear in output")
+	}
+}
+
+func TestSaveConfig_WithRulesOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "order-test.yml")
+
+	// Create config with rules in specific order
+	cfg := &Config{
+		AreaID:     "JP13",
+		FileFormat: radigo.AudioFormatAAC,
+		Rules: radikron.Rules{
+			&radikron.Rule{Name: "rule1", StationID: "FMT", Title: "First"},
+			&radikron.Rule{Name: "rule2", StationID: "TBS", Title: "Second"},
+			&radikron.Rule{Name: "rule3", StationID: "MBS", Title: "Third"},
+		},
+	}
+
+	// Save config
+	err := cfg.SaveConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error saving config, got: %v", err)
+	}
+
+	// Load and verify order
+	loadedCfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error loading config, got: %v", err)
+	}
+
+	expectedOrder := []string{"rule1", "rule2", "rule3"}
+	if len(loadedCfg.Rules) != len(expectedOrder) {
+		t.Fatalf("expected %d rules, got %d", len(expectedOrder), len(loadedCfg.Rules))
+	}
+
+	for i, expectedName := range expectedOrder {
+		if loadedCfg.Rules[i].Name != expectedName {
+			t.Errorf("rule order mismatch at index %d: expected %s, got %s",
+				i, expectedName, loadedCfg.Rules[i].Name)
+		}
+	}
+}
+
+func TestSaveConfig_EmptyRules(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "empty-rules.yml")
+
+	cfg := &Config{
+		AreaID:     "JP13",
+		FileFormat: radigo.AudioFormatAAC,
+		Rules:      radikron.Rules{},
+	}
+
+	err := cfg.SaveConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error saving config with empty rules, got: %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		t.Fatal("config file was not created")
+	}
+
+	// Load and verify
+	loadedCfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("expected no error loading config, got: %v", err)
+	}
+	if len(loadedCfg.Rules) != 0 {
+		t.Errorf("expected 0 rules, got %d", len(loadedCfg.Rules))
+	}
+}
+
+func TestConvertRulesToYAML_MultipleRules(t *testing.T) {
+	// Test with multiple rules to ensure order is preserved
+	rules := radikron.Rules{
+		&radikron.Rule{Name: "first", StationID: "FMT"},
+		&radikron.Rule{Name: "second", StationID: "TBS"},
+		&radikron.Rule{Name: "third", StationID: "MBS"},
+	}
+
+	rulesMap, order := convertRulesToYAML(rules)
+	if len(rulesMap) != 3 {
+		t.Errorf("expected 3 rules in map, got %d", len(rulesMap))
+	}
+	if len(order) != 3 {
+		t.Errorf("expected order length 3, got %d", len(order))
+	}
+
+	expectedOrder := []string{"first", "second", "third"}
+	for i, expectedName := range expectedOrder {
+		if order[i] != expectedName {
+			t.Errorf("order mismatch at index %d: expected %s, got %s", i, expectedName, order[i])
+		}
+		if _, exists := rulesMap[expectedName]; !exists {
+			t.Errorf("rule %s not found in map", expectedName)
+		}
+	}
+}
+
+func TestConvertRulesToYAML_AllRuleFields(t *testing.T) {
+	// Test with a rule that has all possible fields set
+	rule := &radikron.Rule{
+		Name:      "full-rule",
+		StationID: "FMT",
+		Title:     "Full Title",
+		Keyword:   "keyword",
+		Pfm:       "Person",
+		DoW:       []string{"mon", "tue"},
+		Window:    "48h",
+		Folder:    "test-folder",
+	}
+
+	rules := radikron.Rules{rule}
+	rulesMap, order := convertRulesToYAML(rules)
+
+	if len(order) != 1 || order[0] != "full-rule" {
+		t.Errorf("expected order to contain 'full-rule', got %v", order)
+	}
+
+	ruleYAML, exists := rulesMap["full-rule"]
+	if !exists {
+		t.Fatal("expected rule to be in map")
+	}
+
+	if ruleYAML.StationID != "FMT" {
+		t.Errorf("expected StationID FMT, got %s", ruleYAML.StationID)
+	}
+	if ruleYAML.Title != "Full Title" {
+		t.Errorf("expected Title 'Full Title', got %s", ruleYAML.Title)
+	}
+	if ruleYAML.Keyword != "keyword" {
+		t.Errorf("expected Keyword 'keyword', got %s", ruleYAML.Keyword)
+	}
+	if ruleYAML.Pfm != "Person" {
+		t.Errorf("expected Pfm 'Person', got %s", ruleYAML.Pfm)
+	}
+	if len(ruleYAML.DoW) != 2 {
+		t.Errorf("expected DoW length 2, got %d", len(ruleYAML.DoW))
+	}
+	if ruleYAML.Window != "48h" {
+		t.Errorf("expected Window '48h', got %s", ruleYAML.Window)
+	}
+	if ruleYAML.Folder != "test-folder" {
+		t.Errorf("expected Folder 'test-folder', got %s", ruleYAML.Folder)
+	}
+}
+
+func TestSaveConfig_ErrorPaths(t *testing.T) {
+	cfg := &Config{
+		AreaID:     "JP13",
+		FileFormat: radigo.AudioFormatAAC,
+		Rules:      radikron.Rules{},
+	}
+
+	// Test with invalid path (on Unix, /dev/null/config.yml should fail)
+	// On Windows, we'll use a path with invalid characters
+	invalidPath := string([]rune{0}) + "invalid.yml"
+	err := cfg.SaveConfig(invalidPath)
+	// filepath.Abs may or may not error depending on platform, so we just verify it doesn't panic
+	// We don't assert on the error since it's platform-dependent
+	if err == nil {
+		t.Log("SaveConfig with invalid path did not error (platform-dependent behavior)")
+	}
+}
+
+func TestMarshalConfigWithOrder_WithRules(t *testing.T) {
+	// Test marshaling config with rules to ensure all code paths are covered
+	cfg := &configYAML{
+		AreaID:     "JP13",
+		FileFormat: "aac",
+		Rules: map[string]*ruleYAML{
+			"test-rule": {
+				StationID: "FMT",
+				Title:     "Test Title",
+				Keyword:   "test",
+				Pfm:       "Test Person",
+				DoW:       []string{"mon", "tue"},
+				Window:    "48h",
+				Folder:    "test-folder",
+			},
+		},
+		rulesOrder: []string{"test-rule"},
+	}
+
+	data, err := marshalConfigWithOrder(cfg)
+	if err != nil {
+		t.Fatalf("expected no error marshaling config with rules, got: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty YAML data")
+	}
+
+	// Verify it can be unmarshaled and rules are present
+	var result struct {
+		Rules map[string]*ruleYAML `yaml:"rules"`
+	}
+	if err := yaml.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if _, exists := result.Rules["test-rule"]; !exists {
+		t.Error("expected test-rule to be in output")
+	}
+}
+
+func TestMarshalConfigWithOrder_MultipleRulesOrder(t *testing.T) {
+	// Test with multiple rules to ensure order is preserved in marshaling
+	cfg := &configYAML{
+		AreaID:     "JP13",
+		FileFormat: "aac",
+		Rules: map[string]*ruleYAML{
+			"first":  {StationID: "FMT"},
+			"second": {StationID: "TBS"},
+			"third":  {StationID: "MBS"},
+		},
+		rulesOrder: []string{"first", "second", "third"},
+	}
+
+	data, err := marshalConfigWithOrder(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Read the YAML as text to verify order
+	yamlStr := string(data)
+	firstPos := findStringPosition(yamlStr, "first:")
+	secondPos := findStringPosition(yamlStr, "second:")
+	thirdPos := findStringPosition(yamlStr, "third:")
+
+	if firstPos == -1 || secondPos == -1 || thirdPos == -1 {
+		t.Fatal("not all rules found in output")
+	}
+
+	if firstPos >= secondPos || secondPos >= thirdPos {
+		t.Errorf("rules not in correct order: first at %d, second at %d, third at %d",
+			firstPos, secondPos, thirdPos)
+	}
+}
+
+func findStringPosition(s, substr string) int {
+	idx := 0
+	for {
+		pos := findStringInLines(s, substr, idx)
+		if pos == -1 {
+			return -1
+		}
+		// Check if it's actually a rule name (not part of another string)
+		before := pos - 1
+		after := pos + len(substr)
+		if (before < 0 || s[before] == '\n' || s[before] == ' ') &&
+			(after >= len(s) || s[after] == ':' || s[after] == '\n') {
+			return pos
+		}
+		idx = pos + 1
+	}
+}
+
+func findStringInLines(s, substr string, start int) int {
+	for i := start; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Fixes #57

This PR fixes the issue where rule order was not preserved when loading rules from the config file and displaying them in the RulesEditor component. Rule order is important because it determines folder precedence when a program matches multiple rules.

## Changes

- Implement custom YAML marshaler (`marshalConfigWithOrder`) to preserve rule order when saving config files
- Add `rulesOrder` field to `configYAML` struct to track rule order
- Update `convertRulesToYAML` to return both map and order slice with named return values
- Add comprehensive test coverage (`TestSaveConfigPreservesRuleOrder`) to verify rule order preservation
- Update existing `TestSaveConfig` to verify order preservation
- Fix linter issues: name return values and combine append calls
- Update README to document rule order precedence for folder sorting

## Technical Details

The issue was that when saving config files, rules were converted to a `map[string]*ruleYAML`, and YAML marshaling of Go maps doesn't preserve order. The solution uses `yaml.Node` to manually construct the YAML structure while preserving the order of rules.

## Testing

- All existing tests pass
- New test verifies rule order is preserved through multiple save/load cycles
- Test confirms order is maintained when loading from existing config files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Rule Order Precedence note and emphasized that the first matching rule (by config order) determines a program's destination.

* **Bug Fixes**
  * Preserved rule ordering when saving and loading configurations so rule priority is retained.

* **Tests**
  * Expanded test coverage to verify rule-order persistence across save/load cycles and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->