### PR TITLE
feat(gui): filter scheduled downloads and rename WeeklyProgram to ProgramSearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ config.yaml
 # downloads
 /radiko
 
+# tests
+/coverage.txt
+/coverage.html
+
 # misc
 *.bak
 .DS_Store

--- a/cmd/radikron-gui/app.go
+++ b/cmd/radikron-gui/app.go
@@ -215,6 +215,53 @@ func (a *App) GetConfigFile() (string, error) {
 	return a.configFile, nil
 }
 
+// GetSchedules returns the current scheduled programs that haven't been downloaded yet
+func (a *App) GetSchedules() (radikron.Progs, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if a.asset == nil {
+		return nil, fmt.Errorf("asset not initialized")
+	}
+
+	// Filter out programs whose files already exist
+	pendingSchedules := make(radikron.Progs, 0, len(a.asset.Schedules))
+	for _, prog := range a.asset.Schedules {
+		// Check if the file already exists
+		startTime, err := time.ParseInLocation(radikron.DatetimeLayout, prog.Ft, radikron.Location)
+		if err != nil {
+			// Skip programs with invalid start time
+			continue
+		}
+
+		fileBaseName := fmt.Sprintf(
+			"%s_%s_%s",
+			startTime.In(radikron.Location).Format(radikron.OutputDatetimeLayout),
+			prog.StationID,
+			prog.Title,
+		)
+
+		// Create output config using the exported function
+		output, err := radikron.NewOutputConfig(
+			fileBaseName,
+			a.asset.OutputFormat,
+			a.asset.DownloadDir,
+			prog.RuleFolder,
+		)
+		if err != nil {
+			// Skip programs where we can't create output config
+			continue
+		}
+
+		// Only include programs whose files don't exist yet
+		if !output.IsExist() {
+			pendingSchedules = append(pendingSchedules, prog)
+		}
+	}
+
+	return pendingSchedules, nil
+}
+
 // LoadConfig loads configuration from a file
 func (a *App) LoadConfig(filename string) error {
 	a.mu.Lock()

--- a/cmd/radikron-gui/frontend/src/App.tsx
+++ b/cmd/radikron-gui/frontend/src/App.tsx
@@ -6,7 +6,8 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Dashboard } from "@/components/Dashboard";
 import { RulesEditor } from "@/components/RulesEditor";
-import { WeeklyProgramBrowser } from "@/components/WeeklyProgramBrowser";
+import { ScheduledDownloads } from "@/components/ScheduledDownloads";
+import { ProgramSearchBrowser } from "@/components/ProgramSearchBrowser";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { useAppStore } from "@/store/useAppStore";
 import { useThemeStore } from "@/store/useThemeStore";
@@ -222,7 +223,8 @@ const AppComponent: React.FC = () => {
                 <TabsList>
                   <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
                   <TabsTrigger value="rules">Rules Editor</TabsTrigger>
-                  <TabsTrigger value="programs">Weekly Programs</TabsTrigger>
+                  <TabsTrigger value="scheduled">Scheduled Downloads</TabsTrigger>
+                  <TabsTrigger value="programs">Program Search</TabsTrigger>
                 </TabsList>
 
                 <div className="flex items-center gap-4">
@@ -255,8 +257,11 @@ const AppComponent: React.FC = () => {
               <TabsContent value="rules">
                 <RulesEditor />
               </TabsContent>
+              <TabsContent value="scheduled">
+                <ScheduledDownloads />
+              </TabsContent>
               <TabsContent value="programs">
-                <WeeklyProgramBrowser />
+                <ProgramSearchBrowser />
               </TabsContent>
             </div>
           </main>

--- a/cmd/radikron-gui/frontend/src/components/ProgramSearchBrowser.tsx
+++ b/cmd/radikron-gui/frontend/src/components/ProgramSearchBrowser.tsx
@@ -55,7 +55,7 @@ const SanitizedHTML: React.FC<SanitizedHTMLProps> = ({ html, className }) => {
   );
 };
 
-export const WeeklyProgramBrowser: React.FC = () => {
+export const ProgramSearchBrowser: React.FC = () => {
   const stationsRaw = useAppStore((state) => state.stations);
   // Sort stations alphabetically
   const stations = [...stationsRaw].sort((a, b) => a.localeCompare(b));

--- a/cmd/radikron-gui/frontend/src/components/ProgramSearchBrowser.tsx
+++ b/cmd/radikron-gui/frontend/src/components/ProgramSearchBrowser.tsx
@@ -251,7 +251,15 @@ export const ProgramSearchBrowser: React.FC = () => {
                     <Card
                       key={program.ID}
                       className="p-4 cursor-pointer hover:bg-accent transition-colors"
+                      role="button"
+                      tabIndex={0}
                       onClick={() => setSelectedProgram(program)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setSelectedProgram(program);
+                        }
+                      }}
                     >
                       <div className="space-y-2">
                         <div className="flex items-start justify-between">

--- a/cmd/radikron-gui/frontend/src/components/ScheduledDownloads.tsx
+++ b/cmd/radikron-gui/frontend/src/components/ScheduledDownloads.tsx
@@ -1,0 +1,252 @@
+import React, { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { EventsOn } from '../../wailsjs/runtime/runtime';
+import * as App from '../../wailsjs/go/main/App';
+import { radikron } from '../../wailsjs/go/models';
+import { BrowserOpenURL } from '../../wailsjs/runtime/runtime';
+
+// SanitizedHTML renders HTML content safely with XSS protection
+interface SanitizedHTMLProps {
+  html: string;
+  className?: string;
+}
+
+const SanitizedHTML: React.FC<SanitizedHTMLProps> = ({ html, className }) => {
+  const sanitizedHTML = DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'a', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+    ALLOWED_ATTR: ['href', 'target', 'rel'],
+  });
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    const link = target.closest('a');
+    if (link && link.href) {
+      e.preventDefault();
+      BrowserOpenURL(link.href);
+    }
+  };
+
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: sanitizedHTML }}
+      onClick={handleClick}
+    />
+  );
+};
+
+export const ScheduledDownloads: React.FC = () => {
+  const [schedules, setSchedules] = useState<radikron.Prog[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedProgram, setSelectedProgram] = useState<radikron.Prog | null>(null);
+
+  const loadSchedules = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const results: any[] = await App.GetSchedules();
+      const convertedSchedules: radikron.Prog[] = results.map((prog: any) =>
+        radikron.Prog.createFrom(prog)
+      );
+      setSchedules(convertedSchedules);
+    } catch (err) {
+      console.error('Failed to load schedules:', err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(`Failed to load scheduled downloads: ${errorMessage}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSchedules();
+    // Refresh schedules every 5 seconds
+    const interval = setInterval(loadSchedules, 5000);
+    
+    // Listen for download events to refresh schedules
+    const unsubscribeDownloadStarted = EventsOn('download-started', () => {
+      loadSchedules();
+    });
+    const unsubscribeDownloadCompleted = EventsOn('download-completed', () => {
+      loadSchedules();
+    });
+    const unsubscribeFileSaved = EventsOn('file-saved', () => {
+      loadSchedules();
+    });
+    
+    return () => {
+      clearInterval(interval);
+      unsubscribeDownloadStarted();
+      unsubscribeDownloadCompleted();
+      unsubscribeFileSaved();
+    };
+  }, []);
+
+  const formatDateTime = (dateTimeStr: string): string => {
+    if (dateTimeStr.length !== 14) {
+      return dateTimeStr;
+    }
+    const year = dateTimeStr.substring(0, 4);
+    const month = dateTimeStr.substring(4, 6);
+    const day = dateTimeStr.substring(6, 8);
+    const hour = dateTimeStr.substring(8, 10);
+    const minute = dateTimeStr.substring(10, 12);
+    return `${year}-${month}-${day} ${hour}:${minute}`;
+  };
+
+  return (
+    <div className="flex items-center justify-center px-4 py-8">
+      <Card className="w-full max-w-6xl flex flex-col h-[600px]">
+        <CardHeader className="flex-shrink-0">
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Scheduled Downloads</CardTitle>
+              <CardDescription>
+                Programs queued for download based on matching rules
+              </CardDescription>
+            </div>
+            <Button onClick={loadSchedules} disabled={isLoading} variant="outline">
+              {isLoading ? 'Refreshing...' : 'Refresh'}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="flex-1 min-h-0 flex flex-col gap-4">
+          {error && (
+            <div className="flex-shrink-0 p-4 rounded-md bg-destructive/10 text-destructive border border-destructive/20">
+              {error}
+            </div>
+          )}
+
+          {!error && schedules.length > 0 && (
+            <div className="flex-1 flex flex-col min-h-0">
+              <div className="flex-shrink-0 text-sm text-muted-foreground mb-2">
+                {schedules.length} scheduled program{schedules.length !== 1 ? 's' : ''}
+              </div>
+              <div className="flex-1 min-h-0 overflow-hidden">
+                <ScrollArea className="h-full">
+                  <div className="space-y-3 pr-4">
+                    {schedules.map((program) => (
+                      <Card
+                        key={program.ID}
+                        className="p-4 cursor-pointer hover:bg-accent"
+                        onClick={() => setSelectedProgram(program)}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <h3 className="font-semibold text-lg mb-1">{program.Title}</h3>
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <Badge variant="outline">{program.StationID}</Badge>
+                              {program.Pfm && (
+                                <span className="text-sm text-muted-foreground">
+                                  Host: {program.Pfm}
+                                </span>
+                              )}
+                              {program.RuleName && (
+                                <Badge variant="secondary">Rule: {program.RuleName}</Badge>
+                              )}
+                            </div>
+                            <div className="mt-2 text-sm text-muted-foreground">
+                              <p>Start: {formatDateTime(program.Ft)}</p>
+                              <p>End: {formatDateTime(program.To)}</p>
+                            </div>
+                          </div>
+                        </div>
+                      </Card>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </div>
+            </div>
+          )}
+
+          {!error && !isLoading && schedules.length === 0 && (
+            <div className="flex-shrink-0 text-center py-8 text-muted-foreground">
+              <p>No programs scheduled for download.</p>
+              <p className="text-sm mt-2">Programs will appear here once they match your rules.</p>
+            </div>
+          )}
+
+          {isLoading && schedules.length === 0 && (
+            <div className="flex-shrink-0 text-center py-8 text-muted-foreground">
+              <p>Loading scheduled downloads...</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={selectedProgram !== null} onOpenChange={(open) => !open && setSelectedProgram(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto [&>button]:text-foreground [&>button:hover]:text-foreground [&>button]:opacity-100 [&>button>svg]:text-foreground">
+          {selectedProgram && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{selectedProgram.Title}</DialogTitle>
+                <DialogDescription>
+                  <div className="flex items-center gap-2 mt-2">
+                    <Badge variant="outline">{selectedProgram.StationID}</Badge>
+                    {selectedProgram.Pfm && (
+                      <span className="text-sm text-foreground">Host: {selectedProgram.Pfm}</span>
+                    )}
+                    {selectedProgram.RuleName && (
+                      <Badge variant="secondary">Rule: {selectedProgram.RuleName}</Badge>
+                    )}
+                  </div>
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground mb-1">Time</p>
+                  <p className="text-sm text-foreground">
+                    {formatDateTime(selectedProgram.Ft)} - {formatDateTime(selectedProgram.To)}
+                  </p>
+                </div>
+                {selectedProgram.Desc && (
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground mb-1">Description</p>
+                    <SanitizedHTML
+                      html={selectedProgram.Desc}
+                      className="text-sm text-foreground [&_*]:text-foreground [&_a]:text-primary [&_a]:underline [&_a:hover]:opacity-80"
+                    />
+                  </div>
+                )}
+                {selectedProgram.Info && (
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground mb-1">Info</p>
+                    <SanitizedHTML
+                      html={selectedProgram.Info}
+                      className="text-sm text-foreground [&_*]:text-foreground [&_a]:text-primary [&_a]:underline [&_a:hover]:opacity-80"
+                    />
+                  </div>
+                )}
+                {selectedProgram.Tags && selectedProgram.Tags.length > 0 && (
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground mb-1">Tags</p>
+                    <div className="flex flex-wrap gap-2">
+                      {selectedProgram.Tags.map((tag, index) => (
+                        <Badge key={index} variant="outline">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+

--- a/cmd/radikron-gui/frontend/src/components/ScheduledDownloads.tsx
+++ b/cmd/radikron-gui/frontend/src/components/ScheduledDownloads.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -51,8 +51,11 @@ export const ScheduledDownloads: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedProgram, setSelectedProgram] = useState<radikron.Prog | null>(null);
+  const isFetchingRef = useRef(false);
 
-  const loadSchedules = async () => {
+  const loadSchedules = useCallback(async () => {
+    if (isFetchingRef.current) return;
+    isFetchingRef.current = true;
     setIsLoading(true);
     setError(null);
     try {
@@ -66,9 +69,10 @@ export const ScheduledDownloads: React.FC = () => {
       const errorMessage = err instanceof Error ? err.message : String(err);
       setError(`Failed to load scheduled downloads: ${errorMessage}`);
     } finally {
+      isFetchingRef.current = false;
       setIsLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     loadSchedules();
@@ -92,7 +96,7 @@ export const ScheduledDownloads: React.FC = () => {
       unsubscribeDownloadCompleted();
       unsubscribeFileSaved();
     };
-  }, []);
+  }, [loadSchedules]);
 
   const formatDateTime = (dateTimeStr: string): string => {
     if (dateTimeStr.length !== 14) {
@@ -141,7 +145,15 @@ export const ScheduledDownloads: React.FC = () => {
                       <Card
                         key={program.ID}
                         className="p-4 cursor-pointer hover:bg-accent"
+                        role="button"
+                        tabIndex={0}
                         onClick={() => setSelectedProgram(program)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setSelectedProgram(program);
+                          }
+                        }}
                       >
                         <div className="flex items-start justify-between">
                           <div className="flex-1">

--- a/cmd/radikron-gui/frontend/wailsjs/go/main/App.d.ts
+++ b/cmd/radikron-gui/frontend/wailsjs/go/main/App.d.ts
@@ -13,6 +13,8 @@ export function GetConfigFile():Promise<string>;
 
 export function GetMonitoringStatus():Promise<boolean>;
 
+export function GetSchedules():Promise<radikron.Progs>;
+
 export function LoadConfig(arg1:string):Promise<void>;
 
 export function OpenDirectory(arg1:string):Promise<void>;

--- a/cmd/radikron-gui/frontend/wailsjs/go/main/App.js
+++ b/cmd/radikron-gui/frontend/wailsjs/go/main/App.js
@@ -22,6 +22,10 @@ export function GetMonitoringStatus() {
   return window['go']['main']['App']['GetMonitoringStatus']();
 }
 
+export function GetSchedules() {
+  return window['go']['main']['App']['GetSchedules']();
+}
+
 export function LoadConfig(arg1) {
   return window['go']['main']['App']['LoadConfig'](arg1);
 }

--- a/download.go
+++ b/download.go
@@ -178,7 +178,7 @@ func setupOutputConfig(ctx context.Context, asset *Asset, prog *Prog, startTime 
 		prog.Title,
 	)
 
-	output, err := newOutputConfig(
+	output, err := NewOutputConfig(
 		fileBaseName,
 		asset.OutputFormat,
 		asset.DownloadDir,
@@ -547,12 +547,12 @@ func getChunklistFromM3U8(uri string) ([]string, error) {
 	return getChunklist(resp.Body)
 }
 
-// getRadikronPath resolves a provided path (or defaults to the user's Downloads/radiko directory).
+// GetRadikronPath resolves a provided path (or defaults to the user's Downloads/radiko directory).
 // If a relative path is provided, it's resolved relative to the current working directory.
 // If an absolute path is provided, it's used as-is.
 // If no path is provided, it defaults to the user's Downloads/radiko directory,
 // with a fallback to the current working directory/radiko if the home directory cannot be determined.
-func getRadikronPath(path string) (string, error) {
+func GetRadikronPath(path string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current working directory: %w", err)
@@ -660,7 +660,7 @@ func checkConfiguredFoldersForDuplicate(
 	downloadDir, fileBaseName, fileFormat, targetPath string,
 ) (exists bool, existingPath string) {
 	for folder := range configuredFolders {
-		configuredPath, err := getRadikronPath(filepath.Join(downloadDir, folder))
+		configuredPath, err := GetRadikronPath(filepath.Join(downloadDir, folder))
 		if err != nil {
 			continue
 		}
@@ -733,7 +733,7 @@ func handleDuplicate(
 	}
 
 	// Check in default download directory
-	defaultPath, err := getRadikronPath(downloadDir)
+	defaultPath, err := GetRadikronPath(downloadDir)
 	if err != nil {
 		return nil
 	}
@@ -755,13 +755,13 @@ func handleDuplicate(
 	return nil
 }
 
-// newOutputConfig prepares the outputdir
-func newOutputConfig(fileBaseName, fileFormat, downloadDir, folder string) (*radigo.OutputConfig, error) {
+// NewOutputConfig prepares the outputdir
+func NewOutputConfig(fileBaseName, fileFormat, downloadDir, folder string) (*radigo.OutputConfig, error) {
 	basePath := downloadDir
 	if folder != "" {
 		basePath = filepath.Join(downloadDir, folder)
 	}
-	fullPath, err := getRadikronPath(basePath)
+	fullPath, err := GetRadikronPath(basePath)
 	if err != nil {
 		return nil, err
 	}

--- a/download_test.go
+++ b/download_test.go
@@ -114,50 +114,50 @@ func TestGetRadicronPath(t *testing.T) {
 	}
 
 	// Test with relative path
-	path, err := getRadikronPath("downloads")
+	path, err := GetRadikronPath("downloads")
 	if err != nil {
-		t.Errorf("getRadikronPath with relative path failed: %v", err)
+		t.Errorf("GetRadikronPath with relative path failed: %v", err)
 	}
 	expected := filepath.Join(cwd, "downloads")
 	if path != expected {
-		t.Errorf("getRadikronPath => %v, want %v", path, expected)
+		t.Errorf("GetRadikronPath => %v, want %v", path, expected)
 	}
 
 	// Test with absolute path (cross-platform)
 	tmpDir := os.TempDir()
 	absPath := filepath.Join(tmpDir, "test-downloads")
-	path, err = getRadikronPath(absPath)
+	path, err = GetRadikronPath(absPath)
 	if err != nil {
-		t.Errorf("getRadikronPath with absolute path failed: %v", err)
+		t.Errorf("GetRadikronPath with absolute path failed: %v", err)
 	}
 	if path != absPath {
-		t.Errorf("getRadikronPath with absolute path => %v, want %v", path, absPath)
+		t.Errorf("GetRadikronPath with absolute path => %v, want %v", path, absPath)
 	}
 
 	// Test with subdirectory
-	path, err = getRadikronPath(filepath.Join("downloads", "subfolder"))
+	path, err = GetRadikronPath(filepath.Join("downloads", "subfolder"))
 	if err != nil {
-		t.Errorf("getRadikronPath with subdirectory failed: %v", err)
+		t.Errorf("GetRadikronPath with subdirectory failed: %v", err)
 	}
 	expected = filepath.Join(cwd, "downloads", "subfolder")
 	if path != expected {
-		t.Errorf("getRadikronPath with subdirectory => %v, want %v", path, expected)
+		t.Errorf("GetRadikronPath with subdirectory => %v, want %v", path, expected)
 	}
 
 	// Test path cleaning (with .. and .)
-	path, err = getRadikronPath(filepath.Join("downloads", "..", "downloads", ".", "sub"))
+	path, err = GetRadikronPath(filepath.Join("downloads", "..", "downloads", ".", "sub"))
 	if err != nil {
-		t.Errorf("getRadikronPath with path cleaning failed: %v", err)
+		t.Errorf("GetRadikronPath with path cleaning failed: %v", err)
 	}
 	expected = filepath.Join(cwd, "downloads", "sub")
 	if path != expected {
-		t.Errorf("getRadikronPath with path cleaning => %v, want %v", path, expected)
+		t.Errorf("GetRadikronPath with path cleaning => %v, want %v", path, expected)
 	}
 
 	// Test with empty path (default case - should use $HOME/Downloads/radiko)
-	path, err = getRadikronPath("")
+	path, err = GetRadikronPath("")
 	if err != nil {
-		t.Errorf("getRadikronPath with empty path failed: %v", err)
+		t.Errorf("GetRadikronPath with empty path failed: %v", err)
 	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -167,45 +167,45 @@ func TestGetRadicronPath(t *testing.T) {
 		expected = filepath.Join(homeDir, "Downloads", "radiko")
 	}
 	if path != expected {
-		t.Errorf("getRadikronPath with empty path => %v, want %v", path, expected)
+		t.Errorf("GetRadikronPath with empty path => %v, want %v", path, expected)
 	}
 }
 
 func TestNewOutputConfig(t *testing.T) {
 	// Test without folder
-	output, err := newOutputConfig("test-file", radigo.AudioFormatAAC, "downloads", "")
+	output, err := NewOutputConfig("test-file", radigo.AudioFormatAAC, "downloads", "")
 	if err != nil {
-		t.Fatalf("newOutputConfig failed: %v", err)
+		t.Fatalf("NewOutputConfig failed: %v", err)
 	}
 	if output == nil {
-		t.Fatal("newOutputConfig returned nil")
+		t.Fatal("NewOutputConfig returned nil")
 	}
 	if output.FileBaseName != "test-file" {
-		t.Errorf("newOutputConfig FileBaseName => %v, want test-file", output.FileBaseName)
+		t.Errorf("NewOutputConfig FileBaseName => %v, want test-file", output.FileBaseName)
 	}
 	if output.FileFormat != radigo.AudioFormatAAC {
-		t.Errorf("newOutputConfig FileFormat => %v, want %v", output.FileFormat, radigo.AudioFormatAAC)
+		t.Errorf("NewOutputConfig FileFormat => %v, want %v", output.FileFormat, radigo.AudioFormatAAC)
 	}
 
 	// Test with folder
-	output, err = newOutputConfig("test-file", radigo.AudioFormatMP3, "downloads", "citypop")
+	output, err = NewOutputConfig("test-file", radigo.AudioFormatMP3, "downloads", "citypop")
 	if err != nil {
-		t.Fatalf("newOutputConfig with folder failed: %v", err)
+		t.Fatalf("NewOutputConfig with folder failed: %v", err)
 	}
 	if output == nil {
-		t.Fatal("newOutputConfig with folder returned nil")
+		t.Fatal("NewOutputConfig with folder returned nil")
 	}
 	if output.FileFormat != radigo.AudioFormatMP3 {
-		t.Errorf("newOutputConfig FileFormat => %v, want %v", output.FileFormat, radigo.AudioFormatMP3)
+		t.Errorf("NewOutputConfig FileFormat => %v, want %v", output.FileFormat, radigo.AudioFormatMP3)
 	}
 
 	// Test with custom download directory
-	output, err = newOutputConfig("test-file", radigo.AudioFormatAAC, "my-downloads", "")
+	output, err = NewOutputConfig("test-file", radigo.AudioFormatAAC, "my-downloads", "")
 	if err != nil {
-		t.Errorf("newOutputConfig with custom dir failed: %v", err)
+		t.Errorf("NewOutputConfig with custom dir failed: %v", err)
 	}
 	if output == nil {
-		t.Error("newOutputConfig with custom dir returned nil")
+		t.Error("NewOutputConfig with custom dir returned nil")
 	}
 }
 
@@ -260,9 +260,9 @@ func TestHandleDuplicate_NonexistentFile(t *testing.T) {
 	_, cleanup := setupHandleDuplicateTest(t)
 	defer cleanup()
 
-	output, err := newOutputConfig("nonexistent-file", radigo.AudioFormatAAC, "downloads", "")
+	output, err := NewOutputConfig("nonexistent-file", radigo.AudioFormatAAC, "downloads", "")
 	if err != nil {
-		t.Fatalf("newOutputConfig failed: %v", err)
+		t.Fatalf("NewOutputConfig failed: %v", err)
 	}
 	ctx := context.Background()
 	err = handleDuplicate(
@@ -284,9 +284,9 @@ func TestHandleDuplicate_ExistingInDefaultFolder(t *testing.T) {
 	}
 	file.Close()
 
-	output, err := newOutputConfig("test-file", radigo.AudioFormatAAC, "downloads", "")
+	output, err := NewOutputConfig("test-file", radigo.AudioFormatAAC, "downloads", "")
 	if err != nil {
-		t.Fatalf("newOutputConfig failed: %v", err)
+		t.Fatalf("NewOutputConfig failed: %v", err)
 	}
 	ctx := context.Background()
 	err = handleDuplicate(ctx, "test-file", radigo.AudioFormatAAC, "downloads", "", output, Rules{}, "TEST", "Test Program", "20230605100000")
@@ -350,9 +350,9 @@ func TestHandleDuplicate_ExistingInConfiguredFolder(t *testing.T) {
 	}
 	file.Close()
 
-	output, err := newOutputConfig("move-test", radigo.AudioFormatAAC, "downloads", "citypop")
+	output, err := NewOutputConfig("move-test", radigo.AudioFormatAAC, "downloads", "citypop")
 	if err != nil {
-		t.Fatalf("newOutputConfig failed: %v", err)
+		t.Fatalf("NewOutputConfig failed: %v", err)
 	}
 	ctx := context.Background()
 	err = handleDuplicate(
@@ -389,9 +389,9 @@ func TestHandleDuplicate_ConflictBothLocations(t *testing.T) {
 	}
 	file.Close()
 
-	output, err := newOutputConfig("conflict-test", radigo.AudioFormatAAC, "downloads", "citypop")
+	output, err := NewOutputConfig("conflict-test", radigo.AudioFormatAAC, "downloads", "citypop")
 	if err != nil {
-		t.Fatalf("newOutputConfig failed: %v", err)
+		t.Fatalf("NewOutputConfig failed: %v", err)
 	}
 	ctx := context.Background()
 	err = handleDuplicate(
@@ -439,9 +439,9 @@ func TestHandleDuplicate_ChecksAllConfiguredFolders(t *testing.T) {
 	}
 
 	// Try to handle duplicate with citypop as configured folder, but file exists in jazz
-	output, err := newOutputConfig("test-file", radigo.AudioFormatAAC, "downloads", "citypop")
+	output, err := NewOutputConfig("test-file", radigo.AudioFormatAAC, "downloads", "citypop")
 	if err != nil {
-		t.Fatalf("newOutputConfig failed: %v", err)
+		t.Fatalf("NewOutputConfig failed: %v", err)
 	}
 	ctx := context.Background()
 	err = handleDuplicate(
@@ -2042,9 +2042,9 @@ func TestHandleMoveFromDefaultFolder_MoveErrorTargetAppears(t *testing.T) {
 		t.Fatalf("Failed to create default file: %v", err)
 	}
 
-	output, err := newOutputConfig("move-test", radigo.AudioFormatAAC, "downloads", "citypop")
+	output, err := NewOutputConfig("move-test", radigo.AudioFormatAAC, "downloads", "citypop")
 	if err != nil {
-		t.Fatalf("newOutputConfig failed: %v", err)
+		t.Fatalf("NewOutputConfig failed: %v", err)
 	}
 	targetFile := output.AbsPath()
 
@@ -2074,12 +2074,12 @@ func TestHandleMoveFromDefaultFolder_MoveErrorTargetAppears(t *testing.T) {
 func TestGetRadicronPath_GetwdError(t *testing.T) {
 	// This is hard to test directly, but we can verify the error path exists
 	// by checking the code handles Getwd errors
-	// getRadikronPath calls os.Getwd() which rarely fails, but the code should handle it
+	// GetRadikronPath calls os.Getwd() which rarely fails, but the code should handle it
 	// We can't easily mock os.Getwd, but we verify the error handling exists
-	_, err := getRadikronPath("test")
+	_, err := GetRadikronPath("test")
 	// Should succeed in normal cases
 	if err != nil {
-		t.Logf("getRadikronPath returned error (may be expected in some environments): %v", err)
+		t.Logf("GetRadikronPath returned error (may be expected in some environments): %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR resolves #55

## Changes

- **Export utility functions**: Exported `GetRadikronPath` and `NewOutputConfig` functions from the `radikron` package to follow DRY principles
- **Filter completed downloads**: Updated `GetSchedules` to only return programs whose files don't exist yet, preventing completed downloads from appearing in the Scheduled Downloads tab
- **Rename component**: Renamed `WeeklyProgramBrowser` to `ProgramSearchBrowser` for better clarity
- **Update UI labels**: Changed tab label from "Weekly Programs" to "Program Search"

## Technical Details

- `GetSchedules` now checks if output files exist using the same logic as the download system
- Uses exported `radikron.NewOutputConfig` instead of duplicating path resolution logic
- All references and imports have been updated accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Scheduled Downloads" tab showing queued radio programs with automatic 5-second refresh and event-driven updates
  * Program detail dialogs with title, station, host, rule, start/end times, tags, and safely rendered descriptions with external-link support

* **Updates**
  * Replaced "Weekly Programs" tab with "Program Search"

* **Accessibility**
  * Program cards are keyboard-focusable and activate on Enter/Space

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->