### PR TITLE
feat(ui): add configuration editor with export and station selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Sometimes we miss our favorite shows on [radiko.jp](https://radiko.jp/) and they
 
 radikron is a powerful, automated radio program downloader for [radiko](https://radiko.jp/) available in both **CLI** and **GUI** versions. Both versions share the same core logic, ensuring consistent behavior and reliability.
 
-![config-editor](https://github.com/user-attachments/assets/4f3e0509-d669-4e48-8adf-da50827925ed)
-![program-search](https://github.com/user-attachments/assets/ba4741c9-37d8-4d20-ad8b-d6f2d21364bc)
-
 ### 🖥️ Dual Interface Support
 
 - **CLI Version**: Lightweight command-line interface for servers and automation
@@ -92,6 +89,9 @@ Manually add any program to the download queue (past or future), with persistent
 ### 🖱️ GUI Features
 
 Configuration management, station browser, program search with filtering, scheduled downloads view, monitoring control, and real-time activity logs.
+
+![config-editor](https://github.com/user-attachments/assets/4f3e0509-d669-4e48-8adf-da50827925ed)
+![program-search](https://github.com/user-attachments/assets/ba4741c9-37d8-4d20-ad8b-d6f2d21364bc)
 
 ### 🐳 Docker Support
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Sometimes we miss our favorite shows on [radiko.jp](https://radiko.jp/) and they
 
 radikron is a powerful, automated radio program downloader for [radiko](https://radiko.jp/) available in both **CLI** and **GUI** versions. Both versions share the same core logic, ensuring consistent behavior and reliability.
 
+![config-editor](https://github.com/user-attachments/assets/4f3e0509-d669-4e48-8adf-da50827925ed)
+![program-search](https://github.com/user-attachments/assets/ba4741c9-37d8-4d20-ad8b-d6f2d21364bc)
+
 ### 🖥️ Dual Interface Support
 
 - **CLI Version**: Lightweight command-line interface for servers and automation

--- a/cmd/radikron-gui/app.go
+++ b/cmd/radikron-gui/app.go
@@ -1322,26 +1322,28 @@ func (a *App) ReadConfigFile() (string, error) {
 
 // ExportConfigFile opens a save file dialog and saves the config file to the selected location
 func (a *App) ExportConfigFile() error {
+	// Acquire read lock only long enough to copy configFile
 	a.mu.RLock()
-	defer a.mu.RUnlock()
+	configFile := a.configFile
+	a.mu.RUnlock()
 
-	if a.configFile == "" {
+	if configFile == "" {
 		return fmt.Errorf("config file path not set")
 	}
 
-	// Read the config file content
-	content, err := os.ReadFile(a.configFile)
+	// Read the config file content (no lock needed for file I/O)
+	content, err := os.ReadFile(configFile)
 	if err != nil {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
 	// Get the default filename from the config file path
-	defaultFilename := filepath.Base(a.configFile)
+	defaultFilename := filepath.Base(configFile)
 	if defaultFilename == "" {
 		defaultFilename = "config.yml"
 	}
 
-	// Open save file dialog
+	// Open save file dialog (no lock needed for dialog operations)
 	savePath, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
 		DefaultFilename: defaultFilename,
 		Title:           "Save Configuration File",
@@ -1364,7 +1366,7 @@ func (a *App) ExportConfigFile() error {
 		return fmt.Errorf("no file path selected")
 	}
 
-	// Write the content to the selected file
+	// Write the content to the selected file (no lock needed for file I/O)
 	if err := os.WriteFile(savePath, content, manualInjectionsFilePerm); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}

--- a/cmd/radikron-gui/app.go
+++ b/cmd/radikron-gui/app.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	goRuntime "runtime"
+	"sort"
 	"sync"
 	"time"
 
@@ -1302,6 +1303,91 @@ func (a *App) SaveConfig(filename string) error {
 	return nil
 }
 
+// ReadConfigFile reads the config file content and returns it as a string
+func (a *App) ReadConfigFile() (string, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if a.configFile == "" {
+		return "", fmt.Errorf("config file path not set")
+	}
+
+	content, err := os.ReadFile(a.configFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	return string(content), nil
+}
+
+// ExportConfigFile opens a save file dialog and saves the config file to the selected location
+func (a *App) ExportConfigFile() error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if a.configFile == "" {
+		return fmt.Errorf("config file path not set")
+	}
+
+	// Read the config file content
+	content, err := os.ReadFile(a.configFile)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	// Get the default filename from the config file path
+	defaultFilename := filepath.Base(a.configFile)
+	if defaultFilename == "" {
+		defaultFilename = "config.yml"
+	}
+
+	// Open save file dialog
+	savePath, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
+		DefaultFilename: defaultFilename,
+		Title:           "Save Configuration File",
+		Filters: []runtime.FileFilter{
+			{
+				DisplayName: "YAML Files (*.yml, *.yaml)",
+				Pattern:     "*.yml;*.yaml",
+			},
+			{
+				DisplayName: "All Files (*.*)",
+				Pattern:     "*.*",
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("save dialog cancelled or failed: %w", err)
+	}
+
+	if savePath == "" {
+		return fmt.Errorf("no file path selected")
+	}
+
+	// Write the content to the selected file
+	if err := os.WriteFile(savePath, content, 0600); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+// SelectDirectory opens a directory picker dialog and returns the selected directory path
+func (a *App) SelectDirectory() (string, error) {
+	selectedPath, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
+		Title: "Select Download Directory",
+	})
+	if err != nil {
+		return "", fmt.Errorf("directory dialog cancelled or failed: %w", err)
+	}
+
+	if selectedPath == "" {
+		return "", fmt.Errorf("no directory selected")
+	}
+
+	return selectedPath, nil
+}
+
 // GetAvailableStations returns the list of available stations
 func (a *App) GetAvailableStations() ([]string, error) {
 	a.mu.RLock()
@@ -1312,6 +1398,26 @@ func (a *App) GetAvailableStations() ([]string, error) {
 	}
 
 	return a.asset.AvailableStations, nil
+}
+
+// GetAllStations returns all stations from asset.Stations (all possible stations, not just available ones)
+func (a *App) GetAllStations() ([]string, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if a.asset == nil {
+		return nil, fmt.Errorf("asset not initialized")
+	}
+
+	allStations := make([]string, 0, len(a.asset.Stations))
+	for stationID := range a.asset.Stations {
+		allStations = append(allStations, stationID)
+	}
+
+	// Sort for consistent ordering
+	sort.Strings(allStations)
+
+	return allStations, nil
 }
 
 // FetchProgramSnapshots fetches program snapshots from all available stations.

--- a/cmd/radikron-gui/app.go
+++ b/cmd/radikron-gui/app.go
@@ -1357,7 +1357,7 @@ func (a *App) ExportConfigFile() error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("save dialog cancelled or failed: %w", err)
+		return fmt.Errorf("save dialog canceled or failed: %w", err)
 	}
 
 	if savePath == "" {
@@ -1365,7 +1365,7 @@ func (a *App) ExportConfigFile() error {
 	}
 
 	// Write the content to the selected file
-	if err := os.WriteFile(savePath, content, 0600); err != nil {
+	if err := os.WriteFile(savePath, content, manualInjectionsFilePerm); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
@@ -1378,7 +1378,7 @@ func (a *App) SelectDirectory() (string, error) {
 		Title: "Select Download Directory",
 	})
 	if err != nil {
-		return "", fmt.Errorf("directory dialog cancelled or failed: %w", err)
+		return "", fmt.Errorf("directory dialog canceled or failed: %w", err)
 	}
 
 	if selectedPath == "" {

--- a/cmd/radikron-gui/frontend/src/components/Configuration.tsx
+++ b/cmd/radikron-gui/frontend/src/components/Configuration.tsx
@@ -83,7 +83,7 @@ export const Configuration: React.FC = () => {
   const handleEdit = async () => {
     if (!configInfo) return;
     // Convert MinimumOutputSize from bytes to MB (1 MB = 1024 * 1024 bytes)
-    const minimumOutputSizeMB = configInfo.MinimumOutputSize
+    const minimumOutputSizeMB = configInfo.MinimumOutputSize != null
       ? (configInfo.MinimumOutputSize / (1024 * 1024)).toString()
       : '1';
     

--- a/cmd/radikron-gui/frontend/src/components/Configuration.tsx
+++ b/cmd/radikron-gui/frontend/src/components/Configuration.tsx
@@ -1,12 +1,53 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useAppStore } from '@/store/useAppStore';
 import * as App from '../../wailsjs/go/main/App';
-import { getAreaName } from '@/lib/regions';
+import { config } from '../../wailsjs/go/models';
+import { getAreaName, regionsData } from '@/lib/regions';
+import { toast } from 'sonner';
+import { X, Plus } from 'lucide-react';
+
+// Flatten all regions into a single array for the select dropdown
+const allRegions = Object.values(regionsData).flat();
 
 export const Configuration: React.FC = () => {
   const configInfo = useAppStore((state) => state.configInfo);
+  const stations = useAppStore((state) => state.stations);
   const addActivityLog = useAppStore((state) => state.addActivityLog);
+  const loadConfigInfo = useAppStore((state) => state.loadConfigInfo);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [allStations, setAllStations] = useState<string[]>([]);
+  const [editedConfig, setEditedConfig] = useState<{
+    AreaID: string;
+    FileFormat: string;
+    DownloadDir: string;
+    ExtraStations: string[];
+    IgnoreStations: string[];
+    MinimumOutputSize: string; // In MB, as string for input
+    MaxDownloadingConcurrency: string; // As string for input
+    MaxEncodingConcurrency: string; // As string for input
+  } | null>(null);
+  const [selectedExtraStation, setSelectedExtraStation] = useState<string>('');
+  const [selectedIgnoreStation, setSelectedIgnoreStation] = useState<string>('');
 
   const handleOpenDirectory = async (dirPath: string) => {
     if (!dirPath || dirPath === 'N/A') {
@@ -20,6 +61,104 @@ export const Configuration: React.FC = () => {
         error instanceof Error ? error.message : String(error);
       addActivityLog('error', `Failed to open directory: ${errorMessage}`);
     }
+  };
+
+  const handleExport = async () => {
+    try {
+      await App.ExportConfigFile();
+      toast.success('Configuration exported successfully');
+      addActivityLog('success', 'Configuration exported');
+    } catch (error) {
+      console.error('Failed to export config:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      // Don't show error if user cancelled the dialog
+      if (!errorMessage.includes('cancelled')) {
+        toast.error(`Failed to export config: ${errorMessage}`);
+        addActivityLog('error', `Failed to export config: ${errorMessage}`);
+      }
+    }
+  };
+
+  const handleEdit = async () => {
+    if (!configInfo) return;
+    // Convert MinimumOutputSize from bytes to MB (1 MB = 1024 * 1024 bytes)
+    const minimumOutputSizeMB = configInfo.MinimumOutputSize
+      ? (configInfo.MinimumOutputSize / (1024 * 1024)).toString()
+      : '1';
+    
+    // Load all stations for Extra Stations selector
+    try {
+      const allStationsList = await App.GetAllStations();
+      setAllStations(allStationsList);
+    } catch (error) {
+      console.error('Failed to load all stations:', error);
+      setAllStations([]);
+    }
+    
+    setEditedConfig({
+      AreaID: configInfo.AreaID || '',
+      FileFormat: configInfo.FileFormat || 'aac',
+      DownloadDir: configInfo.DownloadDir || '',
+      ExtraStations: configInfo.ExtraStations || [],
+      IgnoreStations: configInfo.IgnoreStations || [],
+      MinimumOutputSize: minimumOutputSizeMB,
+      MaxDownloadingConcurrency: configInfo.MaxDownloadingConcurrency?.toString() || '64',
+      MaxEncodingConcurrency: configInfo.MaxEncodingConcurrency?.toString() || '2',
+    });
+    setSelectedExtraStation('');
+    setSelectedIgnoreStation('');
+    setIsEditDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!editedConfig || !configInfo) return;
+
+    try {
+      // Use the station arrays directly
+      const extraStations = editedConfig.ExtraStations || [];
+      const ignoreStations = editedConfig.IgnoreStations || [];
+
+      // Convert MinimumOutputSize from MB to bytes
+      const minimumOutputSizeMB = parseFloat(editedConfig.MinimumOutputSize) || 1;
+      const minimumOutputSizeBytes = Math.round(minimumOutputSizeMB * 1024 * 1024);
+
+      // Parse numeric fields
+      const maxDownloadingConcurrency = parseInt(editedConfig.MaxDownloadingConcurrency, 10) || 64;
+      const maxEncodingConcurrency = parseInt(editedConfig.MaxEncodingConcurrency, 10) || 2;
+
+      // Create updated config object with all required fields
+      const updatedConfig = new config.Config({
+        ...configInfo,
+        AreaID: editedConfig.AreaID,
+        FileFormat: editedConfig.FileFormat,
+        DownloadDir: editedConfig.DownloadDir,
+        ExtraStations: extraStations,
+        IgnoreStations: ignoreStations,
+        MinimumOutputSize: minimumOutputSizeBytes,
+        MaxDownloadingConcurrency: maxDownloadingConcurrency,
+        MaxEncodingConcurrency: maxEncodingConcurrency,
+      });
+
+      await App.UpdateConfig(updatedConfig);
+      await App.SaveConfig('');
+      await loadConfigInfo();
+
+      setIsEditDialogOpen(false);
+      toast.success('Configuration saved successfully');
+      addActivityLog('success', 'Configuration updated');
+    } catch (error) {
+      console.error('Failed to save config:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to save config: ${errorMessage}`);
+      addActivityLog('error', `Failed to save config: ${errorMessage}`);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditDialogOpen(false);
+    setEditedConfig(null);
   };
 
   return (
@@ -70,7 +209,328 @@ export const Configuration: React.FC = () => {
         ) : (
           <p className="text-sm text-muted-foreground">No configuration loaded</p>
         )}
+        <div className="flex gap-2 pt-2">
+          <Button
+            onClick={handleExport}
+            disabled={!configInfo}
+            className="flex-1"
+            variant="outline"
+          >
+            Export
+          </Button>
+          <Button
+            onClick={handleEdit}
+            disabled={!configInfo}
+            className="flex-1"
+            variant="outline"
+          >
+            Edit
+          </Button>
+        </div>
       </CardContent>
+
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="text-foreground [&>button]:text-foreground [&>button:hover]:text-foreground [&>button]:opacity-100 [&>button>svg]:text-foreground max-h-[90vh] overflow-y-auto max-w-4xl">
+          <DialogHeader>
+            <DialogTitle className="text-foreground">Edit Configuration</DialogTitle>
+            <DialogDescription className="text-muted-foreground">
+              Edit the configuration parameters below.
+            </DialogDescription>
+          </DialogHeader>
+          {editedConfig && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="area-id" className="text-foreground">Area ID</Label>
+                <Select
+                  value={editedConfig.AreaID}
+                  onValueChange={(value) =>
+                    setEditedConfig({ ...editedConfig, AreaID: value })
+                  }
+                >
+                  <SelectTrigger id="area-id" className="text-foreground">
+                    <SelectValue placeholder="Select area" />
+                  </SelectTrigger>
+                  <SelectContent className="text-foreground">
+                    {allRegions.map((region) => (
+                      <SelectItem key={region.id} value={region.id}>
+                        {region.id} - {region.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="file-format" className="text-foreground">File Format</Label>
+                <Select
+                  value={editedConfig.FileFormat}
+                  onValueChange={(value) =>
+                    setEditedConfig({
+                      ...editedConfig,
+                      FileFormat: value,
+                    })
+                  }
+                >
+                  <SelectTrigger id="file-format" className="text-foreground">
+                    <SelectValue placeholder="Select format" />
+                  </SelectTrigger>
+                  <SelectContent className="text-foreground">
+                    <SelectItem value="aac">AAC</SelectItem>
+                    <SelectItem value="mp3">MP3</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="download-dir" className="text-foreground">Download Directory</Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="download-dir"
+                    value={editedConfig.DownloadDir}
+                    readOnly
+                    placeholder="/path/to/downloads"
+                    className="text-foreground flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={async () => {
+                      try {
+                        const selectedPath = await App.SelectDirectory();
+                        setEditedConfig({
+                          ...editedConfig,
+                          DownloadDir: selectedPath,
+                        });
+                      } catch (error) {
+                        // Don't show error if user cancelled the dialog
+                        const errorMessage =
+                          error instanceof Error ? error.message : String(error);
+                        if (!errorMessage.includes('cancelled')) {
+                          toast.error(`Failed to select directory: ${errorMessage}`);
+                        }
+                      }
+                    }}
+                  >
+                    Browse
+                  </Button>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="extra-stations" className="text-foreground">
+                  Extra Stations
+                </Label>
+                <div className="flex gap-2">
+                  <Select
+                    value={selectedExtraStation}
+                    onValueChange={setSelectedExtraStation}
+                  >
+                    <SelectTrigger className="text-foreground flex-1">
+                      <SelectValue placeholder="Select station" />
+                    </SelectTrigger>
+                    <SelectContent className="text-foreground">
+                      {allStations
+                        .filter((station) => 
+                          !editedConfig.ExtraStations.includes(station) &&
+                          !stations.includes(station)
+                        )
+                        .map((station) => (
+                          <SelectItem key={station} value={station}>
+                            {station}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => {
+                      if (selectedExtraStation && !editedConfig.ExtraStations.includes(selectedExtraStation)) {
+                        setEditedConfig({
+                          ...editedConfig,
+                          ExtraStations: [...editedConfig.ExtraStations, selectedExtraStation],
+                        });
+                        setSelectedExtraStation('');
+                      }
+                    }}
+                    disabled={!selectedExtraStation}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </div>
+                {editedConfig.ExtraStations.length > 0 && (
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {editedConfig.ExtraStations.map((station) => (
+                      <Badge
+                        key={station}
+                        variant="secondary"
+                        className="text-foreground"
+                      >
+                        {station}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditedConfig({
+                              ...editedConfig,
+                              ExtraStations: editedConfig.ExtraStations.filter((s) => s !== station),
+                            });
+                          }}
+                          className="ml-2 hover:bg-destructive/20 rounded-full p-0.5"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Station IDs to include even if they're not in your region
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ignore-stations" className="text-foreground">
+                  Ignore Stations
+                </Label>
+                <div className="flex gap-2">
+                  <Select
+                    value={selectedIgnoreStation}
+                    onValueChange={setSelectedIgnoreStation}
+                  >
+                    <SelectTrigger className="text-foreground flex-1">
+                      <SelectValue placeholder="Select station" />
+                    </SelectTrigger>
+                    <SelectContent className="text-foreground">
+                      {stations
+                        .filter((station) => !editedConfig.IgnoreStations.includes(station))
+                        .map((station) => (
+                          <SelectItem key={station} value={station}>
+                            {station}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => {
+                      if (selectedIgnoreStation && !editedConfig.IgnoreStations.includes(selectedIgnoreStation)) {
+                        setEditedConfig({
+                          ...editedConfig,
+                          IgnoreStations: [...editedConfig.IgnoreStations, selectedIgnoreStation],
+                        });
+                        setSelectedIgnoreStation('');
+                      }
+                    }}
+                    disabled={!selectedIgnoreStation}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </div>
+                {editedConfig.IgnoreStations.length > 0 && (
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {editedConfig.IgnoreStations.map((station) => (
+                      <Badge
+                        key={station}
+                        variant="secondary"
+                        className="text-foreground"
+                      >
+                        {station}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditedConfig({
+                              ...editedConfig,
+                              IgnoreStations: editedConfig.IgnoreStations.filter((s) => s !== station),
+                            });
+                          }}
+                          className="ml-2 hover:bg-destructive/20 rounded-full p-0.5"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Station IDs to exclude from monitoring
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="minimum-output-size" className="text-foreground">
+                  Minimum Output Size (MB)
+                </Label>
+                <Input
+                  id="minimum-output-size"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={editedConfig.MinimumOutputSize}
+                  onChange={(e) =>
+                    setEditedConfig({
+                      ...editedConfig,
+                      MinimumOutputSize: e.target.value,
+                    })
+                  }
+                  placeholder="1"
+                  className="text-foreground"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Minimum file size in MB. Files smaller than this are rejected as potentially corrupted (default: 1 MB)
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="max-downloading-concurrency" className="text-foreground">
+                  Max Downloading Concurrency
+                </Label>
+                <Input
+                  id="max-downloading-concurrency"
+                  type="number"
+                  min="1"
+                  value={editedConfig.MaxDownloadingConcurrency}
+                  onChange={(e) =>
+                    setEditedConfig({
+                      ...editedConfig,
+                      MaxDownloadingConcurrency: e.target.value,
+                    })
+                  }
+                  placeholder="64"
+                  className="text-foreground"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Maximum number of concurrent download operations (default: 64)
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="max-encoding-concurrency" className="text-foreground">
+                  Max Encoding Concurrency
+                </Label>
+                <Input
+                  id="max-encoding-concurrency"
+                  type="number"
+                  min="1"
+                  value={editedConfig.MaxEncodingConcurrency}
+                  onChange={(e) =>
+                    setEditedConfig({
+                      ...editedConfig,
+                      MaxEncodingConcurrency: e.target.value,
+                    })
+                  }
+                  placeholder="2"
+                  className="text-foreground"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Maximum number of concurrent MP3 encoding operations (default: 2). Set lower than downloading concurrency since encoding is CPU-intensive.
+                </p>
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button onClick={handleCancel} variant="outline">
+              Cancel
+            </Button>
+            <Button onClick={handleSave}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 };

--- a/cmd/radikron-gui/frontend/src/lib/regions.ts
+++ b/cmd/radikron-gui/frontend/src/lib/regions.ts
@@ -1,7 +1,7 @@
 // Region mapping from assets/regions.json
 // Maps area ID (e.g., "JP13") to region name (e.g., "東京")
 
-const regionsData = {
+export const regionsData = {
   "hokkaido-tohoku": [
     { id: "JP1", name: "北海道" },
     { id: "JP2", name: "青森" },

--- a/cmd/radikron-gui/frontend/wailsjs/go/main/App.d.ts
+++ b/cmd/radikron-gui/frontend/wailsjs/go/main/App.d.ts
@@ -5,7 +5,11 @@ import {radikron} from '../models';
 
 export function DeleteManualInjection(arg1:string):Promise<void>;
 
+export function ExportConfigFile():Promise<void>;
+
 export function FetchProgramSnapshots():Promise<void>;
+
+export function GetAllStations():Promise<Array<string>>;
 
 export function GetAvailableStations():Promise<Array<string>>;
 
@@ -31,9 +35,13 @@ export function LoadConfig(arg1:string):Promise<void>;
 
 export function OpenDirectory(arg1:string):Promise<void>;
 
+export function ReadConfigFile():Promise<string>;
+
 export function SaveConfig(arg1:string):Promise<void>;
 
 export function SearchWeeklyPrograms(arg1:string,arg2:string,arg3:string,arg4:string):Promise<radikron.Progs>;
+
+export function SelectDirectory():Promise<string>;
 
 export function StartMonitoring():Promise<void>;
 

--- a/cmd/radikron-gui/frontend/wailsjs/go/main/App.js
+++ b/cmd/radikron-gui/frontend/wailsjs/go/main/App.js
@@ -6,8 +6,16 @@ export function DeleteManualInjection(arg1) {
   return window['go']['main']['App']['DeleteManualInjection'](arg1);
 }
 
+export function ExportConfigFile() {
+  return window['go']['main']['App']['ExportConfigFile']();
+}
+
 export function FetchProgramSnapshots() {
   return window['go']['main']['App']['FetchProgramSnapshots']();
+}
+
+export function GetAllStations() {
+  return window['go']['main']['App']['GetAllStations']();
 }
 
 export function GetAvailableStations() {
@@ -58,12 +66,20 @@ export function OpenDirectory(arg1) {
   return window['go']['main']['App']['OpenDirectory'](arg1);
 }
 
+export function ReadConfigFile() {
+  return window['go']['main']['App']['ReadConfigFile']();
+}
+
 export function SaveConfig(arg1) {
   return window['go']['main']['App']['SaveConfig'](arg1);
 }
 
 export function SearchWeeklyPrograms(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['SearchWeeklyPrograms'](arg1, arg2, arg3, arg4);
+}
+
+export function SelectDirectory() {
+  return window['go']['main']['App']['SelectDirectory']();
 }
 
 export function StartMonitoring() {


### PR DESCRIPTION
Add comprehensive configuration editor to the GUI that allows users to edit all config parameters.

## Features

- **Export Configuration**: Download config file via system save dialog
- **Edit Dialog**: Full-featured configuration editor with 2-column layout
- **Parameter Editing**:
  - Area ID (dropdown with all regions)
  - File Format (AAC/MP3 selector)
  - Download Directory (folder picker dialog)
  - Extra Stations (station selector with badges from asset.Stations)
  - Ignore Stations (station selector with badges from available stations)
  - Minimum Output Size (MB input)
  - Max Downloading/Encoding Concurrency (number inputs)

## Technical Changes

- Add `ExportConfigFile()` method to open system save dialog
- Add `SelectDirectory()` method for folder selection
- Add `GetAllStations()` method to get all stations from asset.Stations
- Implement station selectors with badge-based UI
- Filter Extra Stations to exclude already-available stations
- Improve dark mode visibility with explicit text color classes
- Export regionsData from regions.ts for reuse

Resolves #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration editor: edit, save, and export configuration plus directory browsing.
  * Station listing: view/select available stations.
  * Region data made available for UI population.

* **Documentation**
  * Added two inline feature badges to the README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->