### PR TITLE
fix(ui): trim search keyword and fix README link fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,14 @@ Sometimes we miss our favorite shows on [radiko.jp](https://radiko.jp/) and they
 <!-- vim-markdown-toc GFM -->
 
 - [Features](#features)
-  - [🖥️ Dual Interface Support](#-dual-interface-support)
-  - [🎯 Smart Rule-Based Matching](#-smart-rule-based-matching)
-  - [📁 Flexible File Organization](#-flexible-file-organization)
-  - [🏷️ Automatic ID3 Tagging](#-automatic-id3-tagging)
-  - [🛡️ Intelligent Download Management](#-intelligent-download-management)
-  - [➕ Manual Program Injection](#-manual-program-injection)
-  - [🌐 Multi-Region Support](#-multi-region-support)
-  - [🔄 Continuous Monitoring](#-continuous-monitoring)
-  - [🖱️ GUI Features](#-gui-features)
-  - [🐳 Docker Support](#-docker-support)
+  - [🖥️ Dual Interface Support](#dual-interface-support)
+  - [🎯 Smart Rule-Based Matching](#smart-rule-based-matching)
+  - [📁 Flexible File Organization](#flexible-file-organization)
+  - [🛡️ Intelligent Download Management](#intelligent-download-management)
+  - [➕ Manual Program Injection](#manual-program-injection)
+  - [🌐 Multi-Region & Continuous Monitoring](#multi-region-continuous-monitoring)
+  - [🖱️ GUI Features](#gui-features)
+  - [🐳 Docker Support](#docker-support)
 - [Requirements](#requirements)
 - [Installation](#installation)
   - [CLI Version](#cli-version)
@@ -54,46 +52,46 @@ Sometimes we miss our favorite shows on [radiko.jp](https://radiko.jp/) and they
 
 radikron is a powerful, automated radio program downloader for [radiko](https://radiko.jp/) available in both **CLI** and **GUI** versions. Both versions share the same core logic, ensuring consistent behavior and reliability.
 
-### 🖥️ Dual Interface Support
+### 🖥️ Dual Interface Support {#dual-interface-support}
 
 - **CLI Version**: Lightweight command-line interface for servers and automation
 - **GUI Version**: Modern graphical interface built with Wails v2 for desktop users
 - **Shared Core**: Both versions use the same engine, ensuring consistent behavior
 
-### 🎯 Smart Rule-Based Matching
+### 🎯 Smart Rule-Based Matching {#smart-rule-based-matching}
 
 Flexible rules to automatically capture programs using multiple criteria: title/keyword matching, performer filtering, station selection, day-of-week and time-window filters.
 
-### 📁 Flexible File Organization
+### 📁 Flexible File Organization {#flexible-file-organization}
 
 - Rule-based folder organization with configurable download directories
 - Support for AAC (default) and MP3 formats
 - Automatic ID3 tagging with program metadata
 
-### 🛡️ Intelligent Download Management
+### 🛡️ Intelligent Download Management {#intelligent-download-management}
 
 - Duplicate detection and file size validation
 - Automatic retry with exponential backoff for failed downloads
 - Concurrent downloads and automatic cleanup of stale failures
 
-### ➕ Manual Program Injection
+### ➕ Manual Program Injection {#manual-program-injection}
 
 Manually add any program to the download queue (past or future), with persistent storage and automatic retry. GUI users can easily manage injections through the interface.
 
-### 🌐 Multi-Region & Continuous Monitoring
+### 🌐 Multi-Region & Continuous Monitoring {#multi-region-continuous-monitoring}
 
 - Area-based station filtering with support for extra stations from other regions
 - Continuous background monitoring with scheduled fetching
 - Graceful shutdown that waits for active downloads
 
-### 🖱️ GUI Features
+### 🖱️ GUI Features {#gui-features}
 
 Configuration management, station browser, program search with filtering, scheduled downloads view, monitoring control, and real-time activity logs.
 
 ![config-editor](https://github.com/user-attachments/assets/4f3e0509-d669-4e48-8adf-da50827925ed)
 ![program-search](https://github.com/user-attachments/assets/ba4741c9-37d8-4d20-ad8b-d6f2d21364bc)
 
-### 🐳 Docker Support
+### 🐳 Docker Support {#docker-support}
 
 Pre-built Docker images with all dependencies included, ready for easy deployment.
 

--- a/cmd/radikron-gui/frontend/src/components/ProgramSearchBrowser.tsx
+++ b/cmd/radikron-gui/frontend/src/components/ProgramSearchBrowser.tsx
@@ -115,11 +115,14 @@ export const ProgramSearchBrowser: React.FC = () => {
       // Convert "all" back to empty string for backend
       const stationValue = searchCriteria.station === 'all' ? '' : searchCriteria.station;
       
+      // Trim keyword to avoid whitespace issues in matching
+      const trimmedKeyword = searchCriteria.keyword.trim();
+      
       // @ts-ignore - SearchWeeklyPrograms will be available after Wails rebuild
       const results: any[] = await App.SearchWeeklyPrograms(
         '', // title (not used)
         '', // pfm (not used)
-        searchCriteria.keyword,
+        trimmedKeyword,
         stationValue
       );
 


### PR DESCRIPTION
## Fixes

- **Search keyword trimming**: Trim keyword before passing to backend to prevent whitespace from interfering with search matching
- **README link fragments**: Fix MD051 linting errors by adding explicit anchor IDs to emoji headings

## Changes

### ProgramSearchBrowser.tsx
- Added keyword trimming using `trim()` before passing to `SearchWeeklyPrograms`
- Ensures search results correctly match entered keywords even if user accidentally includes leading/trailing whitespace

### README.md
- Added explicit anchor IDs to all emoji headings (e.g., `{#dual-interface-support}`)
- Resolves markdownlint MD051 errors for link fragment validation
- All table of contents links now properly validate

## Testing

- Verified search works correctly with trimmed keywords
- Confirmed all MD051 linting errors are resolved
- Build passes successfully