### PR TITLE
fix: update to be compatible with the new v3 radiko api

### DIFF
--- a/.github/workflows/golanci-lint.yml
+++ b/.github/workflows/golanci-lint.yml
@@ -44,6 +44,6 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: latest
+          version: v2.11.2
           # Optional:The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
           # install-mode: "goinstall"

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.dylib
 
 # Compiled binary
-radikron
+/radikron
 /radikron-gui
 
 # Test binary, built with `go test -c`

--- a/asset_test.go
+++ b/asset_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewAsset(t *testing.T) {
 	const nAreas = 47
 	const nRegions = 7
-	const nStations = 110
+	const nStations = 109
 	client, err := radiko.New("")
 	if err != nil {
 		t.Error(err)
@@ -156,7 +156,6 @@ func TestGetStationIDsByAreaID(t *testing.T) {
 				"JOAK-FM",
 				"JORF",
 				"LFR",
-				"OC1",
 				"QRR",
 				"RN1",
 				"RN2",
@@ -343,7 +342,7 @@ func TestLoadAvailableStations(t *testing.T) {
 	asset.LoadAvailableStations("JP13")
 
 	expectedStations := []string{
-		"FMJ", "FMT", "INT", "JOAK", "JOAK-FM", "JORF", "LFR", "OC1", "QRR", "RN1", "RN2", "TBS",
+		"FMJ", "FMT", "INT", "JOAK", "JOAK-FM", "JORF", "LFR", "QRR", "RN1", "RN2", "TBS",
 	}
 	less := func(a, b string) bool { return a < b }
 	if !cmp.Equal(asset.AvailableStations, expectedStations, cmpopts.SortSlices(less)) {

--- a/cmd/radikron-gui/app.go
+++ b/cmd/radikron-gui/app.go
@@ -1367,7 +1367,7 @@ func (a *App) ExportConfigFile() error {
 	}
 
 	// Write the content to the selected file (no lock needed for file I/O)
-	if err := os.WriteFile(savePath, content, manualInjectionsFilePerm); err != nil {
+	if err := os.WriteFile(savePath, content, manualInjectionsFilePerm); err != nil { //nolint:gosec // path comes from native save dialog
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 

--- a/cmd/radikron-gui/logger.go
+++ b/cmd/radikron-gui/logger.go
@@ -46,13 +46,12 @@ func (e *WailsEventEmitter) SetDownloadCompletedCallback(callback DownloadComple
 }
 
 // EmitDownloadStarted implements radikron.EventEmitter
-func (e *WailsEventEmitter) EmitDownloadStarted(stationID, title, startTime, uri string) {
-	log.Printf("start downloading [%s]%s (%s): %s", stationID, title, startTime, uri)
+func (e *WailsEventEmitter) EmitDownloadStarted(stationID, title, startTime string) {
+	log.Printf("start downloading [%s]%s (%s)", stationID, title, startTime)
 	runtime.EventsEmit(e.ctx, "download-started", map[string]any{
 		"station": stationID,
 		"title":   title,
 		"start":   startTime,
-		"uri":     uri,
 	})
 }
 

--- a/cmd/radikron/main_test.go
+++ b/cmd/radikron/main_test.go
@@ -48,7 +48,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	got := len(asset.AvailableStations)
-	nStations := 13
+	nStations := 12
 	if got != nStations {
 		t.Errorf("asset.AvailableStations: %v => want %v", got, nStations)
 	}

--- a/const.go
+++ b/const.go
@@ -42,7 +42,7 @@ const (
 	// API endpoints
 	// region full
 	APIRegionFull    = "https://radiko.jp/v3/station/region/full.xml"
-	APIPlaylistM3U8  = "https://radiko.jp/v2/api/ts/playlist.m3u8"
+	APIPlaylistM3U8  = "https://tf-f-rpaa-radiko.smartstream.ne.jp/tf/playlist.m3u8"
 	APIWeeklyProgram = "https://radiko.jp/v3/program/station/weekly/%s.xml"
 
 	// HTTP Headers

--- a/download.go
+++ b/download.go
@@ -1,8 +1,11 @@
 package radikron
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -28,11 +31,11 @@ var (
 )
 
 // emitDownloadStarted emits a download started event if emitter is available, otherwise logs it
-func emitDownloadStarted(ctx context.Context, stationID, title, startTime, uri string) {
+func emitDownloadStarted(ctx context.Context, stationID, title, startTime string) {
 	if emitter := GetEventEmitter(ctx); emitter != nil {
-		emitter.EmitDownloadStarted(stationID, title, startTime, uri)
+		emitter.EmitDownloadStarted(stationID, title, startTime)
 	} else {
-		log.Printf("start downloading [%s]%s (%s): %s", stationID, title, startTime, uri)
+		log.Printf("start downloading [%s]%s (%s)", stationID, title, startTime)
 	}
 }
 
@@ -275,49 +278,14 @@ func Download(
 		return fmt.Errorf("failed to handle duplicate: %w", err)
 	}
 
-	// fetch the recording m3u8 uri
-	uri, err := timeshiftProgM3U8(ctx, prog)
-	if err != nil {
-		msg := fmt.Sprintf("Failed to fetch M3U8 URI: %v", err)
-		emitLogMessage(ctx, "error", msg)
-		return fmt.Errorf(
-			"playlist.m3u8 not available [%s]%s (%s): %s",
-			prog.StationID,
-			title,
-			start,
-			err,
-		)
-	}
 	// Log rule match only when download actually starts (not skipped)
 	if prog.RuleName != "" {
 		emitLogMessage(ctx, "info", fmt.Sprintf("rule[%s] matched: [%s]%s (%s)", prog.RuleName, prog.StationID, title, start))
 	}
-	emitDownloadStarted(ctx, prog.StationID, title, start, uri)
-	prog.M3U8 = uri
+	emitDownloadStarted(ctx, prog.StationID, title, start)
 	wg.Add(1)
 	go downloadProgram(ctx, wg, prog, output)
 	return nil
-}
-
-func buildM3U8RequestURI(prog *Prog) string {
-	u, err := url.Parse(APIPlaylistM3U8)
-	if err != nil {
-		log.Fatal(err)
-	}
-	// set query parameters
-	urlQuery := u.Query()
-	params := map[string]string{
-		"station_id": prog.StationID,
-		"ft":         prog.Ft,
-		"to":         prog.To,
-		"l":          PlaylistM3U8Length, // required?
-	}
-	for k, v := range params {
-		urlQuery.Set(k, v)
-	}
-	u.RawQuery = urlQuery.Encode()
-
-	return u.String()
 }
 
 func bulkDownload(list []string, output string) error {
@@ -333,7 +301,7 @@ func bulkDownload(list []string, output string) error {
 			defer wg.Done()
 
 			var err error
-			for i := 0; i < MaxRetryAttempts; i++ {
+			for range MaxRetryAttempts {
 				downloadingSem <- struct{}{}
 				err = downloadLink(link, output)
 				<-downloadingSem
@@ -392,7 +360,7 @@ func downloadProgram(
 	defer wg.Done()
 	var err error
 
-	chunklist, err := getChunklistFromM3U8(prog.M3U8)
+	chunklist, err := getTimeshiftChunklist(ctx, prog)
 	if err != nil {
 		log.Printf("failed to get chunklist: %s", err)
 		return
@@ -519,39 +487,119 @@ func convertAACtoMP3(ctx context.Context, sourceFile, destFile string) error {
 	return nil
 }
 
-// getChunklist returns a slice of uri string.
-func getChunklist(input io.Reader) ([]string, error) {
-	playlist, listType, err := m3u8.DecodeFrom(input, true)
-	if err != nil || listType != m3u8.MEDIA {
-		return nil, err
-	}
-	p := playlist.(*m3u8.MediaPlaylist)
+// getTimeshiftChunklist returns a slice of chunk urls.
+func getTimeshiftChunklist(
+	ctx context.Context,
+	prog *Prog,
+) ([]string, error) {
+	asset := GetAsset(ctx)
+	client := asset.DefaultClient
+	var err error
 
-	var chunklist []string
-	for _, v := range p.Segments {
-		if v != nil {
-			chunklist = append(chunklist, v.URI)
+	areaID := asset.GetAreaIDByStationID(prog.StationID)
+
+	device, ok := asset.AreaDevices[areaID]
+	if !ok {
+		device, err = asset.NewDevice(ctx, areaID)
+		if err != nil {
+			return nil, err
 		}
 	}
-	return chunklist, nil
-}
 
-// getChunklistFromM3U8 returns a slice of url.
-func getChunklistFromM3U8(uri string) ([]string, error) {
-	resp, err := http.Get(uri) //nolint:gosec,noctx
+	location, err := time.LoadLocation(TZTokyo)
+	if err != nil {
+		panic(err)
+	}
+
+	ft, err := time.ParseInLocation(DatetimeLayout, prog.Ft, location)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	to, err := time.ParseInLocation(DatetimeLayout, prog.To, location)
+	if err != nil {
+		return nil, err
+	}
+	if !to.After(ft) {
+		return nil, fmt.Errorf("invalid program range: ft=%s to=%s", prog.Ft, prog.To)
+	}
 
-	return getChunklist(resp.Body)
+	seen := map[string]bool{}
+	var chunklist []string
+
+	for seek := ft; seek.Before(to); seek = seek.Add(15 * time.Second) {
+		// build m3u8 request uri
+		u, err := url.Parse(APIPlaylistM3U8)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// set query parameters
+		q := u.Query()
+		q.Set("station_id", prog.StationID)
+		q.Set("start_at", prog.Ft)
+		q.Set("ft", prog.Ft)
+		q.Set("end_at", prog.To)
+		q.Set("to", prog.To)
+		q.Set("seek", seek.In(location).Format(DatetimeLayout))
+		q.Set("preroll", "0")
+		q.Set("l", "15")
+		q.Set("lsid", generateLSID())
+		q.Set("type", "b")
+		u.RawQuery = q.Encode()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
+		if err != nil {
+			return nil, err
+		}
+		req = req.WithContext(ctx)
+		req.Header.Set("pragma", "no-cache")
+		//req.Header.Set("X-Radiko-App", "pc_html5")
+		//req.Header.Set("X-Radiko-App-Version", "0.0.1")
+		//req.Header.Set("X-Radiko-User", "dummy_user")
+		//req.Header.Set("X-Radiko-Device", "pc")
+		req.Header.Set(UserAgentHeader, device.UserAgent)
+		req.Header.Set(RadikoAreaIDHeader, areaID)
+		req.Header.Set(RadikoAuthTokenHeader, device.AuthToken)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("request failed (%s): %v", u.String(), err)
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read body failed (%s): %v", u.String(), readErr)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("%s -> %s", u.String(), resp.Status)
+		}
+
+		playlistURI, err := parseMasterPlaylistURI(string(body))
+		if err != nil {
+			return nil, fmt.Errorf("%s -> %v", u.String(), err)
+		}
+
+		chunks, err := parseChunklistFromM3U8(resolveURL(u.String(), playlistURI))
+		if err != nil {
+			return nil, fmt.Errorf("%s -> chunklist parse failed: %v", u.String(), err)
+		}
+		for _, c := range chunks {
+			key := segmentKey(c)
+			if !seen[key] {
+				seen[key] = true
+				chunklist = append(chunklist, c)
+			}
+		}
+	}
+	return chunklist, nil
 }
 
 // GetRadikronPath resolves a provided path (or defaults to the user's Downloads/radiko directory).
 // If a relative path is provided, it's resolved relative to the current working directory.
 // If an absolute path is provided, it's used as-is.
 // If no path is provided, it defaults to the user's Downloads/radiko directory,
-// with a fallback to the current working directory/radiko if the home directory cannot be determined.
+// with a fallback to the current working directory/ctx, prog the home directory cannot be determined.
 func GetRadikronPath(path string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -574,20 +622,6 @@ func GetRadikronPath(path string) (string, error) {
 		}
 	}
 	return filepath.Clean(path), nil
-}
-
-// getURI returns uri generated by parsing m3u8.
-func getURI(input io.Reader) (string, error) {
-	playlist, listType, err := m3u8.DecodeFrom(input, true)
-	if err != nil || listType != m3u8.MASTER {
-		return "", err
-	}
-	p := playlist.(*m3u8.MasterPlaylist)
-
-	if p == nil || len(p.Variants) != 1 || p.Variants[0] == nil {
-		return "", errors.New("invalid m3u8 format")
-	}
-	return p.Variants[0].URI, nil
 }
 
 // newOutputConfigFromPath creates an OutputConfig from a directory path, file base name, and format.
@@ -786,48 +820,6 @@ func tempAACDir() (string, error) {
 	return aacDir, nil
 }
 
-// timeshiftProgM3U8 gets playlist.m3u8 for a Prog
-func timeshiftProgM3U8(
-	ctx context.Context,
-	prog *Prog,
-) (string, error) {
-	asset := GetAsset(ctx)
-	client := asset.DefaultClient
-	var req *http.Request
-	var err error
-
-	areaID := asset.GetAreaIDByStationID(prog.StationID)
-
-	device, ok := asset.AreaDevices[areaID]
-	if !ok {
-		device, err = asset.NewDevice(ctx, areaID)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	uri := buildM3U8RequestURI(prog)
-	req, err = http.NewRequestWithContext(ctx, "POST", uri, http.NoBody)
-	if err != nil {
-		return "", err
-	}
-	headers := map[string]string{
-		UserAgentHeader:       device.UserAgent,
-		RadikoAreaIDHeader:    areaID,
-		RadikoAuthTokenHeader: device.AuthToken,
-	}
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	return getURI(resp.Body)
-}
-
 func writeID3Tag(output *radigo.OutputConfig, prog *Prog) error {
 	tag, err := id3v2.Open(output.AbsPath(), id3v2.Options{Parse: true})
 	if err != nil {
@@ -860,4 +852,83 @@ func writeID3Tag(output *radigo.OutputConfig, prog *Prog) error {
 	}
 
 	return nil
+}
+
+func generateLSID() string {
+	b := make([]byte, 16) // 16 bytes → 32 hex chars
+	if _, err := rand.Read(b); err != nil {
+		log.Fatal(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func extractChunklist(input io.Reader) ([]string, error) {
+	playlist, listType, err := m3u8.DecodeFrom(input, true)
+	if err != nil || listType != m3u8.MEDIA {
+		return nil, err
+	}
+	p := playlist.(*m3u8.MediaPlaylist)
+
+	var chunklist []string
+	for _, v := range p.Segments {
+		if v != nil {
+			chunklist = append(chunklist, v.URI)
+		}
+	}
+	return chunklist, nil
+}
+
+func parseChunklistFromM3U8(uri string) ([]string, error) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return extractChunklist(resp.Body)
+}
+
+func parseMasterPlaylistURI(body string) (string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	expectURI := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#EXT-X-STREAM-INF:") {
+			expectURI = true
+			continue
+		}
+		if expectURI && !strings.HasPrefix(line, "#") {
+			return line, nil
+		}
+	}
+	if strings.Contains(body, "#EXTM3U") {
+		return "", fmt.Errorf("master playlist uri not found")
+	}
+	return "", fmt.Errorf("invalid m3u8 body")
+}
+
+func resolveURL(baseURL, ref string) string {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return ref
+	}
+	uri, err := url.Parse(ref)
+	if err != nil {
+		return ref
+	}
+	return base.ResolveReference(uri).String()
+}
+
+func segmentKey(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if u.Path != "" {
+		return u.Path
+	}
+	return raw
 }

--- a/download.go
+++ b/download.go
@@ -488,6 +488,8 @@ func convertAACtoMP3(ctx context.Context, sourceFile, destFile string) error {
 }
 
 // getTimeshiftChunklist returns a slice of chunk urls.
+//
+//nolint:gocyclo,funlen // keep this function monolithic
 func getTimeshiftChunklist(
 	ctx context.Context,
 	prog *Prog,
@@ -508,7 +510,7 @@ func getTimeshiftChunklist(
 
 	location, err := time.LoadLocation(TZTokyo)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	ft, err := time.ParseInLocation(DatetimeLayout, prog.Ft, location)
@@ -526,7 +528,8 @@ func getTimeshiftChunklist(
 	seen := map[string]bool{}
 	var chunklist []string
 
-	for seek := ft; seek.Before(to); seek = seek.Add(15 * time.Second) {
+	// seek the chunks for every 15 seconds
+	for seek := ft; seek.Before(to); seek = seek.Add(15 * time.Second) { //nolint:mnd
 		// build m3u8 request uri
 		u, err := url.Parse(APIPlaylistM3U8)
 		if err != nil {
@@ -553,10 +556,6 @@ func getTimeshiftChunklist(
 		}
 		req = req.WithContext(ctx)
 		req.Header.Set("pragma", "no-cache")
-		//req.Header.Set("X-Radiko-App", "pc_html5")
-		//req.Header.Set("X-Radiko-App-Version", "0.0.1")
-		//req.Header.Set("X-Radiko-User", "dummy_user")
-		//req.Header.Set("X-Radiko-Device", "pc")
 		req.Header.Set(UserAgentHeader, device.UserAgent)
 		req.Header.Set(RadikoAreaIDHeader, areaID)
 		req.Header.Set(RadikoAuthTokenHeader, device.AuthToken)
@@ -599,7 +598,7 @@ func getTimeshiftChunklist(
 // If a relative path is provided, it's resolved relative to the current working directory.
 // If an absolute path is provided, it's used as-is.
 // If no path is provided, it defaults to the user's Downloads/radiko directory,
-// with a fallback to the current working directory/ctx, prog the home directory cannot be determined.
+// with a fallback to the current working directory if the home directory cannot be determined.
 func GetRadikronPath(path string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -855,7 +854,7 @@ func writeID3Tag(output *radigo.OutputConfig, prog *Prog) error {
 }
 
 func generateLSID() string {
-	b := make([]byte, 16) // 16 bytes → 32 hex chars
+	b := make([]byte, 16) //nolint:mnd // 16 bytes → 32 hex chars
 	if _, err := rand.Read(b); err != nil {
 		log.Fatal(err)
 	}
@@ -879,7 +878,7 @@ func extractChunklist(input io.Reader) ([]string, error) {
 }
 
 func parseChunklistFromM3U8(uri string) ([]string, error) {
-	resp, err := http.Get(uri)
+	resp, err := http.Get(uri) //nolint:gosec,noctx
 	if err != nil {
 		return nil, err
 	}

--- a/download_test.go
+++ b/download_test.go
@@ -30,83 +30,6 @@ const (
 	osWindows = "windows"
 )
 
-func TestBuildM3U8RequestURI(t *testing.T) {
-	prog := &Prog{
-		StationID: "FMT",
-		Ft:        "20230605130000",
-		To:        "20230605145500",
-	}
-	uri := buildM3U8RequestURI(prog)
-	want := "https://radiko.jp/v2/api/ts/playlist.m3u8?ft=20230605130000&l=15&station_id=FMT&to=20230605145500"
-	if uri != want {
-		t.Errorf("buildM3U8RequestURI => %v, want %v", uri, want)
-	}
-
-	// Test with different station
-	prog2 := &Prog{
-		StationID: "TBS",
-		Ft:        "20230605140000",
-		To:        "20230605150000",
-	}
-	uri2 := buildM3U8RequestURI(prog2)
-	if uri2 == uri {
-		t.Error("buildM3U8RequestURI should generate different URIs for different programs")
-	}
-	if uri2 == "" {
-		t.Error("buildM3U8RequestURI returned empty URI")
-	}
-
-	// Verify the URI contains all required parameters
-	if !strings.Contains(uri, "station_id=FMT") {
-		t.Error("URI should contain station_id parameter")
-	}
-	if !strings.Contains(uri, "ft=20230605130000") {
-		t.Error("URI should contain ft parameter")
-	}
-	if !strings.Contains(uri, "to=20230605145500") {
-		t.Error("URI should contain to parameter")
-	}
-	if !strings.Contains(uri, "l=15") {
-		t.Error("URI should contain l parameter with PlaylistM3U8Length")
-	}
-}
-
-func TestGetURI(t *testing.T) {
-	m3u8, err := PlaylistTestM3U8.Open("test/playlist-test.m3u8")
-	if err != nil {
-		t.Error(err)
-	}
-	defer m3u8.Close()
-	uri, err := getURI(m3u8)
-	if err != nil {
-		t.Error(err)
-	}
-	want := "https://radiko.jp/v2/api/ts/chunklist/FsNE6Bt0.m3u8"
-	if uri != want {
-		t.Errorf("getURI => %v, want %v", uri, want)
-	}
-
-	// Test with invalid input (media playlist instead of master)
-	// This would require a media playlist test file, but we can test error handling
-	// by using an invalid reader or empty input
-}
-
-func TestGetURI_InvalidVariants(t *testing.T) {
-	// Test with invalid m3u8 format (not a master playlist)
-	invalidReader := strings.NewReader("not a valid m3u8")
-	_, err := getURI(invalidReader)
-	if err == nil {
-		t.Error("getURI should return error for invalid m3u8 format")
-	}
-
-	// Test with empty input
-	emptyReader := strings.NewReader("")
-	_, err = getURI(emptyReader)
-	if err == nil {
-		t.Error("getURI should return error for empty input")
-	}
-}
-
 func TestGetRadicronPath(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -507,72 +430,6 @@ func TestHandleDuplicate_TargetExistsBeforeMove(t *testing.T) {
 	// Verify target file still exists
 	if _, err := os.Stat(targetFile); os.IsNotExist(err) {
 		t.Error("Target file should still exist")
-	}
-}
-
-func TestGetChunklist(t *testing.T) {
-	// Test with master playlist (should return error or nil)
-	m3u8, err := PlaylistTestM3U8.Open("test/playlist-test.m3u8")
-	if err != nil {
-		t.Fatalf("Failed to open test playlist: %v", err)
-	}
-	defer m3u8.Close()
-
-	// Note: The test file is a master playlist, not a media playlist
-	// getChunklist expects a media playlist, so it should return an error or nil chunklist
-	chunklist, err := getChunklist(m3u8)
-	// getChunklist returns (nil, err) when listType is not MEDIA
-	// The function checks: err != nil || listType != m3u8.MEDIA
-	// For master playlist, listType != MEDIA, so it should return nil chunklist
-	if chunklist != nil {
-		t.Errorf("getChunklist should return nil chunklist for master playlist, got %v", chunklist)
-	}
-	// Error may or may not be nil depending on decode behavior, but chunklist must be nil
-	if err != nil {
-		t.Logf("expected non-media playlist decode error: %v", err)
-	}
-
-	// Test with invalid input (empty reader)
-	emptyReader := strings.NewReader("")
-	chunklist, err = getChunklist(emptyReader)
-	if chunklist != nil {
-		t.Error("getChunklist should return nil chunklist for invalid input")
-	}
-	// Error is expected for invalid input
-	if err == nil {
-		t.Log("getChunklist may or may not return error for invalid input")
-	}
-
-	// Test with invalid m3u8 format
-	invalidReader := strings.NewReader("#EXTM3U\ninvalid content")
-	chunklist, _ = getChunklist(invalidReader)
-	if chunklist != nil {
-		t.Error("getChunklist should return nil chunklist for invalid format")
-	}
-}
-
-func TestGetURIErrorCases(t *testing.T) {
-	// Test with invalid input (empty reader)
-	emptyReader := strings.NewReader("")
-	_, err := getURI(emptyReader)
-	if err == nil {
-		t.Error("getURI should return error for invalid input")
-	}
-
-	// Test with invalid XML (not m3u8)
-	invalidReader := strings.NewReader("<?xml version=\"1.0\"?><invalid></invalid>")
-	_, err = getURI(invalidReader)
-	if err == nil {
-		t.Error("getURI should return error for invalid m3u8 format")
-	}
-
-	// Test with media playlist (should return error, expects master playlist)
-	mediaPlaylist := strings.NewReader("#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:10.0,\nsegment.ts\n")
-	uri, err := getURI(mediaPlaylist)
-	// getURI checks listType != m3u8.MASTER, so media playlist should return error
-	// However, if decode succeeds but listType is MEDIA, it returns empty string and error
-	if err == nil && uri != "" {
-		t.Error("getURI should return error or empty URI for media playlist (expects master)")
 	}
 }
 
@@ -1035,23 +892,6 @@ func TestInitSemaphores(_ *testing.T) {
 	}
 	InitSemaphores(asset3)
 	// Should use defaults
-}
-
-func TestGetChunklistFromM3U8(t *testing.T) {
-	// This function makes HTTP requests, so we need to test it carefully
-	// For now, we'll test error cases that don't require a real server
-
-	// Test with invalid URL (should fail)
-	_, err := getChunklistFromM3U8("http://invalid-url-that-does-not-exist-12345.com/test.m3u8")
-	if err == nil {
-		t.Log("getChunklistFromM3U8 may succeed with network retries, but should eventually fail")
-	}
-
-	// Test with empty URL (should fail)
-	_, err = getChunklistFromM3U8("")
-	if err == nil {
-		t.Error("getChunklistFromM3U8 should return error for empty URL")
-	}
 }
 
 func TestValidateAndCleanupOutputFile(t *testing.T) {
@@ -1606,167 +1446,9 @@ func TestBulkDownload_EmptyList(t *testing.T) {
 	}
 }
 
-func TestGetChunklist_MediaPlaylist(t *testing.T) {
-	// Create a media playlist (not master playlist)
-	mediaPlaylist := `#EXTM3U
-#EXT-X-VERSION:3
-#EXTINF:10.0,
-chunk1.aac
-#EXTINF:10.0,
-chunk2.aac
-#EXTINF:10.0,
-chunk3.aac
-#EXT-X-ENDLIST
-`
-
-	reader := strings.NewReader(mediaPlaylist)
-	chunklist, err := getChunklist(reader)
-	if err != nil {
-		t.Errorf("getChunklist failed: %v", err)
-	}
-	if len(chunklist) != 3 {
-		t.Errorf("Expected 3 chunks, got %d", len(chunklist))
-	}
-	if chunklist[0] != "chunk1.aac" {
-		t.Errorf("First chunk should be chunk1.aac, got %s", chunklist[0])
-	}
-}
-
-func TestGetChunklistFromM3U8_Success(t *testing.T) {
-	// Create a media playlist
-	mediaPlaylist := `#EXTM3U
-#EXT-X-VERSION:3
-#EXTINF:10.0,
-chunk1.aac
-#EXTINF:10.0,
-chunk2.aac
-#EXT-X-ENDLIST
-`
-
-	// Create HTTP server that serves the media playlist
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
-		_, _ = w.Write([]byte(mediaPlaylist))
-	}))
-	defer server.Close()
-
-	chunklist, err := getChunklistFromM3U8(server.URL)
-	if err != nil {
-		t.Errorf("getChunklistFromM3U8 failed: %v", err)
-	}
-	if len(chunklist) != 2 {
-		t.Errorf("Expected 2 chunks, got %d", len(chunklist))
-	}
-}
-
-func TestTimeshiftProgM3U8_NoAsset(t *testing.T) {
-	// Test with no asset in context
-	ctx := context.Background()
-	prog := &Prog{
-		StationID: "FMT",
-		Ft:        "20230605130000",
-		To:        "20230605145500",
-	}
-
-	// This will panic when trying to access nil asset
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("timeshiftProgM3U8 should panic when asset is nil")
-		}
-	}()
-
-	_, _ = timeshiftProgM3U8(ctx, prog)
-	t.Error("timeshiftProgM3U8 should have panicked")
-}
-
-func TestDownloadProgram_ChunklistError(t *testing.T) {
-	// Save original env value
-	testDir := filepath.Join(os.TempDir(), "radikron-test-download-prog")
-	defer os.RemoveAll(testDir)
-
-	ctx := context.Background()
-	wg := &sync.WaitGroup{}
-
-	// Create output config
-	downloadsDir := filepath.Join(testDir, "downloads")
-	err := os.MkdirAll(downloadsDir, DirPermissions)
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %v", err)
-	}
-
-	output := newOutputConfigFromPath(downloadsDir, "test-output", radigo.AudioFormatAAC)
-
-	// Test with invalid M3U8 URL (will cause getChunklistFromM3U8 to fail)
-	prog := &Prog{
-		StationID: "FMT",
-		Title:     "Test Program",
-		M3U8:      "http://invalid-url-that-does-not-exist-12345.com/playlist.m3u8",
-	}
-
-	// downloadProgram runs in a goroutine, so we need to wait for it
-	wg.Add(1)
-	downloadProgram(ctx, wg, prog, output)
-	wg.Wait()
-
-	// Verify output file was not created (download should have failed)
-	if _, err := os.Stat(output.AbsPath()); err == nil {
-		t.Error("Output file should not be created when chunklist fetch fails")
-	}
-}
-
-func TestDownloadProgram_BulkDownloadError(t *testing.T) {
-	testDir := filepath.Join(os.TempDir(), "radikron-test-download-prog")
-	defer os.RemoveAll(testDir)
-
-	ctx := context.Background()
-	wg := &sync.WaitGroup{}
-
-	// Create output config
-	downloadsDir := filepath.Join(testDir, "downloads")
-	err := os.MkdirAll(downloadsDir, DirPermissions)
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %v", err)
-	}
-
-	output := newOutputConfigFromPath(downloadsDir, "test-output", radigo.AudioFormatAAC)
-
-	// Create a media playlist that points to invalid URLs (will cause bulkDownload to fail)
-	mediaPlaylist := `#EXTM3U
-#EXT-X-VERSION:3
-#EXTINF:10.0,
-http://invalid-url-1.com/chunk1.aac
-#EXTINF:10.0,
-http://invalid-url-2.com/chunk2.aac
-#EXT-X-ENDLIST
-`
-
-	// Create HTTP server that serves the media playlist
-	chunkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
-		_, _ = w.Write([]byte(mediaPlaylist))
-	}))
-	defer chunkServer.Close()
-
-	prog := &Prog{
-		StationID: "FMT",
-		Title:     "Test Program",
-		M3U8:      chunkServer.URL,
-	}
-
-	// downloadProgram runs in a goroutine, so we need to wait for it
-	wg.Add(1)
-	downloadProgram(ctx, wg, prog, output)
-	wg.Wait()
-
-	// Verify output file was not created (download should have failed)
-	if _, err := os.Stat(output.AbsPath()); err == nil {
-		t.Error("Output file should not be created when bulkDownload fails")
-	}
-}
-
 // mockEventEmitter is a test implementation of EventEmitter
 type mockEventEmitter struct {
-	downloadStarted   []struct{ stationID, title, startTime, uri string }
+	downloadStarted   []struct{ stationID, title, startTime string }
 	downloadCompleted []struct{ stationID, title, startTime, filePath string }
 	fileSaved         []struct{ stationID, title, filePath string }
 	downloadSkipped   []struct{ reason, stationID, title, startTime string }
@@ -1775,8 +1457,8 @@ type mockEventEmitter struct {
 	logMessages       []struct{ level, message string }
 }
 
-func (m *mockEventEmitter) EmitDownloadStarted(stationID, title, startTime, uri string) {
-	m.downloadStarted = append(m.downloadStarted, struct{ stationID, title, startTime, uri string }{stationID, title, startTime, uri})
+func (m *mockEventEmitter) EmitDownloadStarted(stationID, title, startTime string) {
+	m.downloadStarted = append(m.downloadStarted, struct{ stationID, title, startTime string }{stationID, title, startTime})
 }
 
 func (m *mockEventEmitter) EmitDownloadCompleted(stationID, title, startTime, filePath string) {
@@ -1812,7 +1494,7 @@ func TestEmitDownloadStarted_WithEmitter(t *testing.T) {
 	emitter := &mockEventEmitter{}
 	ctx := context.WithValue(context.Background(), ContextKey("eventEmitter"), emitter)
 
-	emitDownloadStarted(ctx, "FMT", "Test Program", "20230605100000", "http://test.com/playlist.m3u8")
+	emitDownloadStarted(ctx, "FMT", "Test Program", "20230605100000")
 
 	if len(emitter.downloadStarted) != 1 {
 		t.Errorf("Expected 1 download started event, got %d", len(emitter.downloadStarted))
@@ -1826,7 +1508,7 @@ func TestEmitDownloadStarted_WithoutEmitter(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	// Should not panic, just log
-	emitDownloadStarted(ctx, "FMT", "Test Program", "20230605100000", "http://test.com/playlist.m3u8")
+	emitDownloadStarted(ctx, "FMT", "Test Program", "20230605100000")
 }
 
 func TestEmitDownloadCompleted_WithEmitter(t *testing.T) {

--- a/download_test.go
+++ b/download_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/bogem/id3v2"
+	"github.com/yyoshiki41/go-radiko"
 	"github.com/yyoshiki41/radigo"
 )
 
@@ -27,8 +28,15 @@ var (
 )
 
 const (
-	osWindows = "windows"
+	osWindows       = "windows"
+	testInvalidTime = "invalid"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestGetRadicronPath(t *testing.T) {
 	cwd, err := os.Getwd()
@@ -894,6 +902,175 @@ func TestInitSemaphores(_ *testing.T) {
 	// Should use defaults
 }
 
+func TestGetTimeshiftChunklist(t *testing.T) { //nolint:gocyclo // transport assertions intentionally cover complete request flow
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+		radiko.SetHTTPClient(&http.Client{Timeout: 120 * time.Second})
+	})
+
+	var playlistRequests int
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := ""
+		switch {
+		case req.URL.Host == "radiko.jp" && req.URL.Path == "/area":
+			body = `<span class="JP13">Tokyo</span>`
+		case req.URL.Host == "tf-f-rpaa-radiko.smartstream.ne.jp":
+			playlistRequests++
+			if got := req.Header.Get(RadikoAreaIDHeader); got != DefaultArea {
+				t.Errorf("%s = %q, want JP13", RadikoAreaIDHeader, got)
+			}
+			if got := req.Header.Get(RadikoAuthTokenHeader); got != "token" {
+				t.Errorf("%s = %q, want token", RadikoAuthTokenHeader, got)
+			}
+			if got := req.URL.Query().Get("station_id"); got != testStationFMT {
+				t.Errorf("station_id = %q, want FMT", got)
+			}
+			if got := req.URL.Query().Get("seek"); got == "" {
+				t.Error("seek is empty")
+			}
+			body = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=48000\nhttps://chunks.test/list.m3u8\n"
+		case req.URL.Host == "chunks.test":
+			if playlistRequests == 1 {
+				body = "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\nhttps://audio.test/one.aac?token=first\n#EXTINF:15,\nhttps://audio.test/two.aac\n"
+			} else {
+				body = "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\nhttps://audio.test/one.aac?token=second\n#EXTINF:15,\nhttps://audio.test/three.aac\n"
+			}
+		default:
+			t.Fatalf("unexpected request: %s", req.URL)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     http.StatusText(http.StatusOK),
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	http.DefaultTransport = transport
+	radiko.SetHTTPClient(&http.Client{Transport: transport})
+
+	client, err := radiko.New("")
+	if err != nil {
+		t.Fatalf("radiko.New failed: %v", err)
+	}
+	asset := &Asset{
+		DefaultClient: client,
+		AreaDevices: Devices{
+			DefaultArea: {
+				AuthToken: "token",
+				UserAgent: "test-agent",
+			},
+		},
+		Stations: Stations{
+			testStationFMT: {Areas: []string{DefaultArea}},
+		},
+	}
+	ctx := context.WithValue(context.Background(), ContextKey("asset"), asset)
+	prog := &Prog{
+		StationID: testStationFMT,
+		Ft:        "20230605130000",
+		To:        "20230605130030",
+	}
+
+	chunks, err := getTimeshiftChunklist(ctx, prog)
+	if err != nil {
+		t.Fatalf("getTimeshiftChunklist failed: %v", err)
+	}
+	want := []string{
+		"https://audio.test/one.aac?token=first",
+		"https://audio.test/two.aac",
+		"https://audio.test/three.aac",
+	}
+	if len(chunks) != len(want) {
+		t.Fatalf("chunks = %v, want %v", chunks, want)
+	}
+	for i := range want {
+		if chunks[i] != want[i] {
+			t.Errorf("chunks[%d] = %q, want %q", i, chunks[i], want[i])
+		}
+	}
+	if playlistRequests != 2 {
+		t.Errorf("playlist requests = %d, want 2", playlistRequests)
+	}
+}
+
+func TestGetTimeshiftChunklistInvalidTimes(t *testing.T) {
+	asset := &Asset{
+		AreaDevices: Devices{DefaultArea: {}},
+		Stations:    Stations{testStationFMT: {Areas: []string{DefaultArea}}},
+	}
+	ctx := context.WithValue(context.Background(), ContextKey("asset"), asset)
+
+	tests := []struct {
+		name string
+		ft   string
+		to   string
+	}{
+		{name: "invalid start", ft: testInvalidTime, to: "20230605130030"},
+		{name: "invalid end", ft: "20230605130000", to: testInvalidTime},
+		{name: "reversed", ft: "20230605130030", to: "20230605130000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := getTimeshiftChunklist(ctx, &Prog{
+				StationID: testStationFMT,
+				Ft:        tt.ft,
+				To:        tt.to,
+			})
+			if err == nil {
+				t.Fatal("getTimeshiftChunklist returned nil error")
+			}
+		})
+	}
+}
+
+func TestTimeshiftPlaylistHelpers(t *testing.T) {
+	master := "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=48000\nchunklist.m3u8\n"
+	uri, err := parseMasterPlaylistURI(master)
+	if err != nil {
+		t.Fatalf("parseMasterPlaylistURI failed: %v", err)
+	}
+	if uri != "chunklist.m3u8" {
+		t.Errorf("uri = %q, want chunklist.m3u8", uri)
+	}
+
+	for _, body := range []string{"#EXTM3U\n", "not a playlist"} {
+		if _, err := parseMasterPlaylistURI(body); err == nil {
+			t.Errorf("parseMasterPlaylistURI(%q) returned nil error", body)
+		}
+	}
+
+	resolved := resolveURL("https://example.com/path/master.m3u8", "../chunklist.m3u8")
+	if resolved != "https://example.com/chunklist.m3u8" {
+		t.Errorf("resolveURL = %q", resolved)
+	}
+	if key := segmentKey("https://example.com/audio.aac?token=secret"); key != "/audio.aac" {
+		t.Errorf("segmentKey = %q, want /audio.aac", key)
+	}
+
+	media := "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\none.aac\n#EXTINF:15,\ntwo.aac\n"
+	chunks, err := extractChunklist(strings.NewReader(media))
+	if err != nil {
+		t.Fatalf("extractChunklist failed: %v", err)
+	}
+	if len(chunks) != 2 || chunks[0] != "one.aac" || chunks[1] != "two.aac" {
+		t.Errorf("chunks = %v", chunks)
+	}
+	chunks, err = extractChunklist(strings.NewReader(master))
+	if err != nil {
+		t.Fatalf("extractChunklist master playlist failed: %v", err)
+	}
+	if chunks != nil {
+		t.Errorf("extractChunklist master chunks = %v, want nil", chunks)
+	}
+
+	lsid := generateLSID()
+	if len(lsid) != 32 {
+		t.Errorf("generateLSID length = %d, want 32", len(lsid))
+	}
+}
+
 func TestValidateAndCleanupOutputFile(t *testing.T) {
 	testDir := filepath.Join(os.TempDir(), "radikron-test-validate")
 	defer os.RemoveAll(testDir)
@@ -1333,7 +1510,7 @@ func TestBulkDownload_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fileName := filepath.Base(r.URL.Path)
-		_, _ = w.Write([]byte("content for " + fileName))
+		_, _ = w.Write([]byte("content for " + fileName)) //nolint:gosec // test server response contains sanitized path base
 	}))
 	defer server.Close()
 
@@ -1383,7 +1560,7 @@ func TestBulkDownload_WithErrors(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 		fileName := filepath.Base(r.URL.Path)
-		_, _ = w.Write([]byte("content for " + fileName))
+		_, _ = w.Write([]byte("content for " + fileName)) //nolint:gosec // test server response contains sanitized path base
 	}))
 	defer server.Close()
 

--- a/radikron.go
+++ b/radikron.go
@@ -24,7 +24,7 @@ func init() { //nolint:gochecknoinits
 // Implementations can provide structured events to external systems (e.g., GUI).
 type EventEmitter interface {
 	// EmitDownloadStarted emits when a download starts
-	EmitDownloadStarted(stationID, title, startTime, uri string)
+	EmitDownloadStarted(stationID, title, startTime string)
 	// EmitDownloadCompleted emits when a download completes successfully (file written to disk)
 	EmitDownloadCompleted(stationID, title, startTime, filePath string)
 	// EmitFileSaved emits when a file is fully saved with metadata tags


### PR DESCRIPTION
Given the new Radiko API and streaming m3u8 endpoints, update the chunk list retrieval mechanism with incremental seek values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unavailable station from JP13 service area.
  * Updated playlist API endpoint for improved service connectivity.
  * Download start notifications no longer surface the source URI.

* **New Features**
  * Improved time-shifted download handling with more reliable chunk retrieval and duplicate-segment avoidance.

* **Tests**
  * Aligned test data and expectations with current station availability and updated download event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->