### PR TITLE
fix(timeshift): filter non-program segments from chunk collection

### DIFF
--- a/download.go
+++ b/download.go
@@ -30,6 +30,12 @@ var (
 	semMu          sync.Mutex // protects semaphore recreation
 )
 
+const (
+	timeshiftDebugEnv         = "RADIKRON_TIMESHIFT_DEBUG"
+	timeshiftChunklistDumpEnv = "RADIKRON_TIMESHIFT_CHUNKLIST_DUMP"
+	timeshiftDiagnosticPerm   = 0600
+)
+
 // emitDownloadStarted emits a download started event if emitter is available, otherwise logs it
 func emitDownloadStarted(ctx context.Context, stationID, title, startTime string) {
 	if emitter := GetEventEmitter(ctx); emitter != nil {
@@ -494,6 +500,43 @@ func getTimeshiftChunklist(
 	ctx context.Context,
 	prog *Prog,
 ) ([]string, error) {
+	const (
+		seekStep       = 15 * time.Second
+		playlistLength = "20"
+	)
+
+	debugEnvValue := os.Getenv(timeshiftDebugEnv)
+	dumpEnvValue := os.Getenv(timeshiftChunklistDumpEnv)
+	debugTimeshift := timeshiftDebugEnabled()
+	dumpEnabled := dumpEnvValue != ""
+	if debugTimeshift || dumpEnabled {
+		log.Printf( //nolint:gosec // diagnostic environment values are quoted
+			"timeshift diagnostics debug_env=%q dump_env=%q debug_enabled=%t dump_enabled=%t",
+			debugEnvValue,
+			dumpEnvValue,
+			debugTimeshift,
+			dumpEnabled,
+		)
+	}
+
+	var dumpPath string
+	if dumpEnabled {
+		absoluteDumpPath, err := filepath.Abs(dumpEnvValue)
+		if err != nil {
+			log.Printf( //nolint:gosec // developer-supplied diagnostic path is quoted
+				"timeshift chunklist dump path resolution failed path=%q: %v",
+				dumpEnvValue,
+				err,
+			)
+		} else {
+			dumpPath = absoluteDumpPath
+			log.Printf( //nolint:gosec // developer-supplied diagnostic path is quoted
+				"timeshift chunklist dump enabled path=%q",
+				dumpPath,
+			)
+		}
+	}
+
 	asset := GetAsset(ctx)
 	client := asset.DefaultClient
 	var err error
@@ -528,8 +571,8 @@ func getTimeshiftChunklist(
 	seen := map[string]bool{}
 	var chunklist []string
 
-	// seek the chunks for every 15 seconds
-	for seek := ft; seek.Before(to); seek = seek.Add(15 * time.Second) { //nolint:mnd
+	// Overlap requests because HLS segment boundaries may not align with fixed seek intervals.
+	for seek := ft; seek.Before(to); seek = seek.Add(seekStep) {
 		// build m3u8 request uri
 		u, err := url.Parse(APIPlaylistM3U8)
 		if err != nil {
@@ -543,12 +586,16 @@ func getTimeshiftChunklist(
 		q.Set("ft", prog.Ft)
 		q.Set("end_at", prog.To)
 		q.Set("to", prog.To)
-		q.Set("seek", seek.In(location).Format(DatetimeLayout))
+		seekValue := seek.In(location).Format(DatetimeLayout)
+		q.Set("seek", seekValue)
 		q.Set("preroll", "0")
-		q.Set("l", "15")
+		q.Set("l", playlistLength)
 		q.Set("lsid", generateLSID())
 		q.Set("type", "b")
 		u.RawQuery = q.Encode()
+		if debugTimeshift {
+			log.Printf("timeshift seek=%s", seekValue)
+		}
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
 		if err != nil {
@@ -579,16 +626,62 @@ func getTimeshiftChunklist(
 			return nil, fmt.Errorf("%s -> %v", u.String(), err)
 		}
 
-		chunks, err := parseChunklistFromM3U8(resolveURL(u.String(), playlistURI))
+		mediaPlaylistURL := resolveURL(u.String(), playlistURI)
+		if debugTimeshift {
+			log.Printf("timeshift media playlist seek=%s url=%q", seekValue, mediaPlaylistURL)
+		}
+		chunks, err := parseChunklistFromM3U8(mediaPlaylistURL)
 		if err != nil {
 			return nil, fmt.Errorf("%s -> chunklist parse failed: %v", u.String(), err)
 		}
 		for _, c := range chunks {
-			key := segmentKey(c)
-			if !seen[key] {
+			segment, parseErr := parseTimeshiftProgramSegment(c, prog.StationID, ft, to, location)
+			if parseErr != nil {
+				if debugTimeshift {
+					log.Printf(
+						"timeshift chunk skipped seek=%s url=%q reason=%q",
+						seekValue,
+						c,
+						parseErr,
+					)
+				}
+				continue
+			}
+
+			key := segment.key()
+			duplicate := seen[key]
+			if debugTimeshift {
+				log.Printf(
+					"timeshift chunk seek=%s url=%q key=%q timestamp=%s duplicate=%t",
+					seekValue,
+					c,
+					key,
+					segment.Timestamp.Format(DatetimeLayout),
+					duplicate,
+				)
+			}
+			if !duplicate {
 				seen[key] = true
 				chunklist = append(chunklist, c)
 			}
+		}
+	}
+	if debugTimeshift {
+		log.Printf("timeshift final chunk count=%d", len(chunklist))
+	}
+	if dumpPath != "" {
+		if err := dumpChunklist(dumpPath, chunklist); err != nil {
+			log.Printf( //nolint:gosec // developer-supplied diagnostic path is quoted
+				"timeshift chunklist dump failed path=%q: %v",
+				dumpPath,
+				err,
+			)
+		} else {
+			log.Printf( //nolint:gosec // developer-supplied diagnostic path is quoted
+				"timeshift chunklist dumped path=%q count=%d",
+				dumpPath,
+				len(chunklist),
+			)
 		}
 	}
 	return chunklist, nil
@@ -921,13 +1014,148 @@ func resolveURL(baseURL, ref string) string {
 	return base.ResolveReference(uri).String()
 }
 
-func segmentKey(raw string) string {
+type timeshiftProgramSegment struct {
+	Path      string
+	StationID string
+	Date      string
+	Timestamp time.Time
+}
+
+type timeshiftSegmentPath struct {
+	Path      string
+	StationID string
+	Date      string
+	Filename  string
+}
+
+// The random filename suffix may vary between playlist responses.
+// Use station + timestamp as the stable media segment identity.
+func (s timeshiftProgramSegment) key() string {
+	return s.StationID + "/" + s.Timestamp.Format(DatetimeLayout)
+}
+
+func parseTimeshiftSegmentPath(raw string) (timeshiftSegmentPath, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return raw
+		return timeshiftSegmentPath{}, fmt.Errorf("parse url: %w", err)
 	}
-	if u.Path != "" {
-		return u.Path
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	segmentsIndex := -1
+	for i := range parts {
+		if parts[i] == "segments" {
+			segmentsIndex = i
+			break
+		}
 	}
-	return raw
+	if segmentsIndex == -1 || len(parts) <= segmentsIndex+1 {
+		return timeshiftSegmentPath{}, fmt.Errorf("unexpected segment path")
+	}
+	if parts[segmentsIndex+1] != "o" {
+		return timeshiftSegmentPath{}, fmt.Errorf("non-program segment class %q", parts[segmentsIndex+1])
+	}
+	if len(parts) != segmentsIndex+6 {
+		return timeshiftSegmentPath{}, fmt.Errorf("unexpected segment path")
+	}
+
+	return timeshiftSegmentPath{
+		Path:      u.Path,
+		StationID: parts[segmentsIndex+3],
+		Date:      parts[segmentsIndex+4],
+		Filename:  parts[segmentsIndex+5],
+	}, nil
+}
+
+func parseTimeshiftProgramSegment(
+	raw string,
+	stationID string,
+	from time.Time,
+	to time.Time,
+	location *time.Location,
+) (timeshiftProgramSegment, error) {
+	segmentPath, err := parseTimeshiftSegmentPath(raw)
+	if err != nil {
+		return timeshiftProgramSegment{}, err
+	}
+	if segmentPath.StationID != stationID {
+		return timeshiftProgramSegment{}, fmt.Errorf(
+			"station mismatch: got %q want %q",
+			segmentPath.StationID,
+			stationID,
+		)
+	}
+
+	filename := segmentPath.Filename
+	const minimumProgramSegmentFilenameLength = len("20060102_150405_x.aac")
+	if len(filename) < minimumProgramSegmentFilenameLength ||
+		filename[8] != '_' ||
+		filename[15] != '_' ||
+		!strings.HasSuffix(filename, ".aac") {
+		return timeshiftProgramSegment{}, fmt.Errorf("unexpected program segment filename")
+	}
+
+	timestampValue := filename[:8] + filename[9:15]
+	if segmentPath.Date != timestampValue[:8] {
+		return timeshiftProgramSegment{}, fmt.Errorf(
+			"date mismatch: path=%q filename=%q",
+			segmentPath.Date,
+			timestampValue[:8],
+		)
+	}
+	timestamp, err := time.ParseInLocation(DatetimeLayout, timestampValue, location)
+	if err != nil {
+		return timeshiftProgramSegment{}, fmt.Errorf("parse segment timestamp: %w", err)
+	}
+	if timestamp.Before(from) || !timestamp.Before(to) {
+		return timeshiftProgramSegment{}, fmt.Errorf(
+			"timestamp outside program range: %s",
+			timestampValue,
+		)
+	}
+
+	return timeshiftProgramSegment{
+		Path:      segmentPath.Path,
+		StationID: segmentPath.StationID,
+		Date:      segmentPath.Date,
+		Timestamp: timestamp,
+	}, nil
+}
+
+func timeshiftDebugEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(timeshiftDebugEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func dumpChunklist(path string, chunks []string) (err error) {
+	file, err := os.OpenFile(
+		path,
+		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+		timeshiftDiagnosticPerm,
+	)
+	if err != nil {
+		return fmt.Errorf("create dump file: %w", err)
+	}
+	// When truncate, the existing permission remains; chmod to overwrite
+	if err := file.Chmod(timeshiftDiagnosticPerm); err != nil {
+		return fmt.Errorf("chmod dump file: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close dump file: %w", closeErr))
+		}
+	}()
+
+	writer := bufio.NewWriter(file)
+	for i, chunk := range chunks {
+		if _, err := writer.WriteString(chunk + "\n"); err != nil {
+			return fmt.Errorf("write chunk %d: %w", i, err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("flush dump file: %w", err)
+	}
+	return nil
 }

--- a/download.go
+++ b/download.go
@@ -1130,6 +1130,7 @@ func timeshiftDebugEnabled() bool {
 }
 
 func dumpChunklist(path string, chunks []string) (err error) {
+	// #nosec G703 -- developer explicitly selects diagnostic dump destination.
 	file, err := os.OpenFile(
 		path,
 		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,

--- a/download_test.go
+++ b/download_test.go
@@ -1,16 +1,19 @@
 package radikron
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -904,12 +907,21 @@ func TestInitSemaphores(_ *testing.T) {
 
 func TestGetTimeshiftChunklist(t *testing.T) { //nolint:gocyclo // transport assertions intentionally cover complete request flow
 	originalTransport := http.DefaultTransport
+	originalLogWriter := log.Writer()
 	t.Cleanup(func() {
 		http.DefaultTransport = originalTransport
 		radiko.SetHTTPClient(&http.Client{Timeout: 120 * time.Second})
+		log.SetOutput(originalLogWriter)
 	})
 
+	var diagnosticLog bytes.Buffer
+	log.SetOutput(&diagnosticLog)
+	dumpPath := filepath.Join(t.TempDir(), "timeshift-chunks.txt")
+	t.Setenv(timeshiftDebugEnv, "1")
+	t.Setenv(timeshiftChunklistDumpEnv, dumpPath)
+
 	var playlistRequests int
+	var seeks []string
 	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		body := ""
 		switch {
@@ -928,13 +940,30 @@ func TestGetTimeshiftChunklist(t *testing.T) { //nolint:gocyclo // transport ass
 			}
 			if got := req.URL.Query().Get("seek"); got == "" {
 				t.Error("seek is empty")
+			} else {
+				seeks = append(seeks, got)
+			}
+			if got := req.URL.Query().Get("l"); got != "20" {
+				t.Errorf("l = %q, want 20", got)
 			}
 			body = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=48000\nhttps://chunks.test/list.m3u8\n"
 		case req.URL.Host == "chunks.test":
-			if playlistRequests == 1 {
-				body = "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\nhttps://audio.test/one.aac?token=first\n#EXTINF:15,\nhttps://audio.test/two.aac\n"
-			} else {
-				body = "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\nhttps://audio.test/one.aac?token=second\n#EXTINF:15,\nhttps://audio.test/three.aac\n"
+			switch playlistRequests {
+			case 1:
+				body = "#EXTM3U\n#EXT-X-VERSION:3\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130000_one.aac\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130005_two.aac\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/c/x/8/advertisement.aac\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130010_three.aac?token=first\n"
+			case 2:
+				body = "#EXTM3U\n#EXT-X-VERSION:3\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130010_changed.aac?token=second\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130015_four.aac\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130020_five.aac\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130025_six.aac\n" +
+					"#EXTINF:5,\nhttps://audio.test/tf/segments/o/B/FMT/20230605/20230605_130030_tail.aac\n"
+			default:
+				t.Fatalf("unexpected playlist request count: %d", playlistRequests)
 			}
 		default:
 			t.Fatalf("unexpected request: %s", req.URL)
@@ -978,9 +1007,12 @@ func TestGetTimeshiftChunklist(t *testing.T) { //nolint:gocyclo // transport ass
 		t.Fatalf("getTimeshiftChunklist failed: %v", err)
 	}
 	want := []string{
-		"https://audio.test/one.aac?token=first",
-		"https://audio.test/two.aac",
-		"https://audio.test/three.aac",
+		"https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130000_one.aac",
+		"https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130005_two.aac",
+		"https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130010_three.aac?token=first",
+		"https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130015_four.aac",
+		"https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130020_five.aac",
+		"https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130025_six.aac",
 	}
 	if len(chunks) != len(want) {
 		t.Fatalf("chunks = %v, want %v", chunks, want)
@@ -992,6 +1024,39 @@ func TestGetTimeshiftChunklist(t *testing.T) { //nolint:gocyclo // transport ass
 	}
 	if playlistRequests != 2 {
 		t.Errorf("playlist requests = %d, want 2", playlistRequests)
+	}
+	wantSeeks := []string{
+		"20230605130000",
+		"20230605130015",
+	}
+	if !reflect.DeepEqual(seeks, wantSeeks) {
+		t.Errorf("seeks = %v, want %v", seeks, wantSeeks)
+	}
+
+	dump, err := os.ReadFile(dumpPath)
+	if err != nil {
+		t.Fatalf("read chunklist dump failed: %v", err)
+	}
+	wantDump := strings.Join(want, "\n") + "\n"
+	if string(dump) != wantDump {
+		t.Errorf("chunklist dump = %q, want %q", dump, wantDump)
+	}
+
+	logOutput := diagnosticLog.String()
+	for _, wantLog := range []string{
+		`timeshift diagnostics debug_env="1" dump_env="` + dumpPath + `" debug_enabled=true dump_enabled=true`,
+		`timeshift chunklist dump enabled path="` + dumpPath + `"`,
+		"timeshift seek=20230605130000",
+		`timeshift media playlist seek=20230605130000 url="https://chunks.test/list.m3u8"`,
+		`url="https://audio.test/tf/segments/c/x/8/advertisement.aac" reason="non-program segment class \"c\""`,
+		`key="FMT/20230605130010" timestamp=20230605130010 duplicate=true`,
+		`url="https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130030_tail.aac" reason="timestamp outside program range: 20230605130030"`,
+		"timeshift final chunk count=6",
+		`timeshift chunklist dumped path="` + dumpPath + `" count=6`,
+	} {
+		if !strings.Contains(logOutput, wantLog) {
+			t.Errorf("diagnostic log missing %q:\n%s", wantLog, logOutput)
+		}
 	}
 }
 
@@ -1045,8 +1110,82 @@ func TestTimeshiftPlaylistHelpers(t *testing.T) {
 	if resolved != "https://example.com/chunklist.m3u8" {
 		t.Errorf("resolveURL = %q", resolved)
 	}
-	if key := segmentKey("https://example.com/audio.aac?token=secret"); key != "/audio.aac" {
-		t.Errorf("segmentKey = %q, want /audio.aac", key)
+	location, err := time.LoadLocation(TZTokyo)
+	if err != nil {
+		t.Fatalf("time.LoadLocation failed: %v", err)
+	}
+	from, err := time.ParseInLocation(DatetimeLayout, "20260625130000", location)
+	if err != nil {
+		t.Fatalf("parse from failed: %v", err)
+	}
+	to, err := time.ParseInLocation(DatetimeLayout, "20260625140000", location)
+	if err != nil {
+		t.Fatalf("parse to failed: %v", err)
+	}
+	validURL := "https://example.com/tf/segments/o/B/FMT/20260625/20260625_135928_25k91.aac?token=secret"
+	segment, err := parseTimeshiftProgramSegment(validURL, testStationFMT, from, to, location)
+	if err != nil {
+		t.Fatalf("parseTimeshiftProgramSegment failed: %v", err)
+	}
+	if segment.Path != "/tf/segments/o/B/FMT/20260625/20260625_135928_25k91.aac" {
+		t.Errorf("segment.Path = %q", segment.Path)
+	}
+	if key := segment.key(); key != "FMT/20260625135928" {
+		t.Errorf("segment key = %q, want FMT/20260625135928", key)
+	}
+
+	invalidSegments := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "commercial segment",
+			url:  "https://example.com/tf/segments/c/x/8/rBDj5dHm7S4TYZmNkwo7.aac",
+			want: `non-program segment class "c"`,
+		},
+		{
+			name: "wrong station",
+			url:  "https://example.com/tf/segments/o/B/TBS/20260625/20260625_135928_25k91.aac",
+			want: `station mismatch`,
+		},
+		{
+			name: "wrong path date",
+			url:  "https://example.com/tf/segments/o/B/FMT/20260624/20260625_135928_25k91.aac",
+			want: `date mismatch`,
+		},
+		{
+			name: "unparsable filename",
+			url:  "https://example.com/tf/segments/o/B/FMT/20260625/not-a-timestamp.aac",
+			want: `unexpected program segment filename`,
+		},
+		{
+			name: "outside program range",
+			url:  "https://example.com/tf/segments/o/B/FMT/20260625/20260625_140000_tail.aac",
+			want: `timestamp outside program range`,
+		},
+	}
+	for _, tt := range invalidSegments {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseTimeshiftProgramSegment(tt.url, testStationFMT, from, to, location)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("parse error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+
+	t.Setenv(timeshiftDebugEnv, "yes")
+	if !timeshiftDebugEnabled() {
+		t.Error("timeshiftDebugEnabled = false, want true")
+	}
+	t.Setenv(timeshiftDebugEnv, "invalid")
+	if timeshiftDebugEnabled() {
+		t.Error("timeshiftDebugEnabled = true, want false")
+	}
+
+	if err := dumpChunklist(t.TempDir(), []string{"one.aac"}); err == nil ||
+		!strings.Contains(err.Error(), "create dump file") {
+		t.Errorf("dumpChunklist create error = %v", err)
 	}
 
 	media := "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\none.aac\n#EXTINF:15,\ntwo.aac\n"

--- a/download_test.go
+++ b/download_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1043,16 +1044,17 @@ func TestGetTimeshiftChunklist(t *testing.T) { //nolint:gocyclo // transport ass
 	}
 
 	logOutput := diagnosticLog.String()
+	quotedDumpPath := strconv.Quote(dumpPath)
 	for _, wantLog := range []string{
-		`timeshift diagnostics debug_env="1" dump_env="` + dumpPath + `" debug_enabled=true dump_enabled=true`,
-		`timeshift chunklist dump enabled path="` + dumpPath + `"`,
+		`timeshift diagnostics debug_env="1" dump_env=` + quotedDumpPath + ` debug_enabled=true dump_enabled=true`,
+		`timeshift chunklist dump enabled path=` + quotedDumpPath,
 		"timeshift seek=20230605130000",
 		`timeshift media playlist seek=20230605130000 url="https://chunks.test/list.m3u8"`,
 		`url="https://audio.test/tf/segments/c/x/8/advertisement.aac" reason="non-program segment class \"c\""`,
 		`key="FMT/20230605130010" timestamp=20230605130010 duplicate=true`,
 		`url="https://audio.test/tf/segments/o/B/FMT/20230605/20230605_130030_tail.aac" reason="timestamp outside program range: 20230605130030"`,
 		"timeshift final chunk count=6",
-		`timeshift chunklist dumped path="` + dumpPath + `" count=6`,
+		`timeshift chunklist dumped path=` + quotedDumpPath + ` count=6`,
 	} {
 		if !strings.Contains(logOutput, wantLog) {
 			t.Errorf("diagnostic log missing %q:\n%s", wantLog, logOutput)
@@ -1110,6 +1112,30 @@ func TestTimeshiftPlaylistHelpers(t *testing.T) {
 	if resolved != "https://example.com/chunklist.m3u8" {
 		t.Errorf("resolveURL = %q", resolved)
 	}
+
+	media := "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\none.aac\n#EXTINF:15,\ntwo.aac\n"
+	chunks, err := extractChunklist(strings.NewReader(media))
+	if err != nil {
+		t.Fatalf("extractChunklist failed: %v", err)
+	}
+	if len(chunks) != 2 || chunks[0] != "one.aac" || chunks[1] != "two.aac" {
+		t.Errorf("chunks = %v", chunks)
+	}
+	chunks, err = extractChunklist(strings.NewReader(master))
+	if err != nil {
+		t.Fatalf("extractChunklist master playlist failed: %v", err)
+	}
+	if chunks != nil {
+		t.Errorf("extractChunklist master chunks = %v, want nil", chunks)
+	}
+
+	lsid := generateLSID()
+	if len(lsid) != 32 {
+		t.Errorf("generateLSID length = %d, want 32", len(lsid))
+	}
+}
+
+func TestParseTimeshiftProgramSegment(t *testing.T) {
 	location, err := time.LoadLocation(TZTokyo)
 	if err != nil {
 		t.Fatalf("time.LoadLocation failed: %v", err)
@@ -1133,7 +1159,21 @@ func TestTimeshiftPlaylistHelpers(t *testing.T) {
 	if key := segment.key(); key != "FMT/20260625135928" {
 		t.Errorf("segment key = %q, want FMT/20260625135928", key)
 	}
+}
 
+func TestParseTimeshiftProgramSegmentRejectsInvalidURLs(t *testing.T) {
+	location, err := time.LoadLocation(TZTokyo)
+	if err != nil {
+		t.Fatalf("time.LoadLocation failed: %v", err)
+	}
+	from, err := time.ParseInLocation(DatetimeLayout, "20260625130000", location)
+	if err != nil {
+		t.Fatalf("parse from failed: %v", err)
+	}
+	to, err := time.ParseInLocation(DatetimeLayout, "20260625140000", location)
+	if err != nil {
+		t.Fatalf("parse to failed: %v", err)
+	}
 	invalidSegments := []struct {
 		name string
 		url  string
@@ -1164,6 +1204,36 @@ func TestTimeshiftPlaylistHelpers(t *testing.T) {
 			url:  "https://example.com/tf/segments/o/B/FMT/20260625/20260625_140000_tail.aac",
 			want: `timestamp outside program range`,
 		},
+		{
+			name: "before program range",
+			url:  "https://example.com/tf/segments/o/B/FMT/20260625/20260625_125959_early.aac",
+			want: `timestamp outside program range`,
+		},
+		{
+			name: "invalid timestamp",
+			url:  "https://example.com/tf/segments/o/B/FMT/20260625/20260625_136099_bad.aac",
+			want: `parse segment timestamp`,
+		},
+		{
+			name: "missing suffix",
+			url:  "https://example.com/tf/segments/o/B/FMT/20260625/20260625_135928_.aac",
+			want: `unexpected program segment filename`,
+		},
+		{
+			name: "missing segments path",
+			url:  "https://example.com/tf/audio/FMT/20260625/20260625_135928_x.aac",
+			want: `unexpected segment path`,
+		},
+		{
+			name: "short program path",
+			url:  "https://example.com/tf/segments/o/B/FMT/20260625",
+			want: `unexpected segment path`,
+		},
+		{
+			name: "invalid URL escape",
+			url:  "https://example.com/tf/segments/o/B/FMT/%zz",
+			want: `parse url`,
+		},
 	}
 	for _, tt := range invalidSegments {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1173,7 +1243,9 @@ func TestTimeshiftPlaylistHelpers(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestTimeshiftDiagnostics(t *testing.T) {
 	t.Setenv(timeshiftDebugEnv, "yes")
 	if !timeshiftDebugEnabled() {
 		t.Error("timeshiftDebugEnabled = false, want true")
@@ -1188,25 +1260,17 @@ func TestTimeshiftPlaylistHelpers(t *testing.T) {
 		t.Errorf("dumpChunklist create error = %v", err)
 	}
 
-	media := "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:15,\none.aac\n#EXTINF:15,\ntwo.aac\n"
-	chunks, err := extractChunklist(strings.NewReader(media))
+	dumpPath := filepath.Join(t.TempDir(), "chunks.txt")
+	err := dumpChunklist(dumpPath, []string{"one.aac", "two.aac"})
 	if err != nil {
-		t.Fatalf("extractChunklist failed: %v", err)
+		t.Fatalf("dumpChunklist failed: %v", err)
 	}
-	if len(chunks) != 2 || chunks[0] != "one.aac" || chunks[1] != "two.aac" {
-		t.Errorf("chunks = %v", chunks)
-	}
-	chunks, err = extractChunklist(strings.NewReader(master))
+	dump, err := os.ReadFile(dumpPath)
 	if err != nil {
-		t.Fatalf("extractChunklist master playlist failed: %v", err)
+		t.Fatalf("read dump failed: %v", err)
 	}
-	if chunks != nil {
-		t.Errorf("extractChunklist master chunks = %v, want nil", chunks)
-	}
-
-	lsid := generateLSID()
-	if len(lsid) != 32 {
-		t.Errorf("generateLSID length = %d, want 32", len(lsid))
+	if got, want := string(dump), "one.aac\ntwo.aac\n"; got != want {
+		t.Errorf("dump = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Radiko's timeshift playlist API can occasionally return non-program segment URLs such as /segments/c/... mixed into the media playlist. Accepting those URLs made repeated downloads of the same program non-deterministic and could cause audible skips or jumps in the final recording.

This change accepts only timestamped program segments matching the expected /segments/o/.../{station}/{date}/{timestamp}_*.aac shape. The collector now validates station ID, path date, filename timestamp, and program time range before appending a chunk.

The deduplication key is changed to use station ID plus parsed segment timestamp, which is stable across overlapping playlist responses and ignores volatile filename suffixes or query parameters.

The seek strategy now uses a 15s step with a 20s playlist window, keeping a small overlap without the heavier 10s/30s over-fetching approach.

Diagnostics are retained behind opt-in environment variables for future timeshift investigations.

Fixes #76.