### PR TITLE
ci(release): add CLI release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -57,7 +57,7 @@ jobs:
           brew install create-dmg
 
       - name: Install Wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,43 @@ jobs:
           path: artifacts/*
           if-no-files-found: error
 
+  build-cli:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+      CGO_ENABLED: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build CLI artifacts
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: v2.16.0
+          args: release --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload CLI artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: radikron-cli
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          if-no-files-found: error
+
   upload-release:
-    needs: build-gui
+    needs: [build-gui, build-cli]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,17 +143,19 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Build CLI artifacts
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: v2.16.0
@@ -194,4 +196,3 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,16 @@
+version: 2
+
 env:
   - GO111MODULE=on
   - CGO_ENABLED=0
+
 before:
   hooks:
-    - go mod tidy
+    - go mod download
+
 builds:
-  - binary: radikron
+  - id: radikron-cli
+    binary: radikron
     main: ./cmd/radikron
     flags:
       - -trimpath
@@ -17,19 +22,31 @@ builds:
       - amd64
       - arm64
       - 386
-    goarm:
-      - 7
+    ignore:
+      - goos: darwin
+        goarch: 386
+
 archives:
-  - format_overrides:
+  - id: radikron-cli
+    ids:
+      - radikron-cli
+    format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     name_template: >-
-      {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64 {{- else if eq .Arch "386" }}i386 {{- else }}{{ .Arch }}{{ end }}
-signs:
-  - artifacts: checksum
-    args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+
+checksum:
+  name_template: checksums.txt
+
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
     main: ./cmd/radikron
     flags:
       - -trimpath
+    ldflags:
+      - -X main.version={{ .Version }}
     goos:
       - linux
       - darwin

--- a/cmd/radikron/main.go
+++ b/cmd/radikron/main.go
@@ -268,7 +268,7 @@ func main() {
 	// Print version
 	if *printVersion {
 		fmt.Printf("%v\n", version)
-		os.Exit(0)
+		return
 	}
 
 	// Enable debug logging

--- a/cmd/radikron/main.go
+++ b/cmd/radikron/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"runtime/debug"
 	"sync"
 	"syscall"
 	"time"
@@ -16,6 +15,8 @@ import (
 	"github.com/iomz/radikron/internal/config"
 	"github.com/yyoshiki41/go-radiko"
 )
+
+var version = "(devel)"
 
 // ProgramFetcher is an interface for fetching weekly programs
 type ProgramFetcher interface {
@@ -261,13 +262,12 @@ func main() {
 	// Parse flags
 	conf := flag.String("c", "config.yml", "the config.yml to use.")
 	enableDebug := flag.Bool("d", false, "enable debug mode.")
-	version := flag.Bool("v", false, "print version.")
+	printVersion := flag.Bool("v", false, "print version.")
 	flag.Parse()
 
 	// Print version
-	if *version {
-		bi, _ := debug.ReadBuildInfo()
-		fmt.Printf("%v\n", bi.Main.Version)
+	if *printVersion {
+		fmt.Printf("%v\n", version)
 		os.Exit(0)
 	}
 

--- a/cmd/radikron/main_test.go
+++ b/cmd/radikron/main_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +15,46 @@ import (
 	"github.com/yyoshiki41/go-radiko"
 	"github.com/yyoshiki41/radigo"
 )
+
+func TestMainPrintsVersion(t *testing.T) {
+	oldArgs := os.Args
+	oldCommandLine := flag.CommandLine
+	oldStdout := os.Stdout
+	oldVersion := version
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		flag.CommandLine = oldCommandLine
+		os.Stdout = oldStdout
+		version = oldVersion
+	})
+
+	os.Args = []string{"radikron", "-v"}
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	version = "v1.2.3-test"
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	os.Stdout = writer
+
+	main()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+
+	if got, want := string(output), "v1.2.3-test\n"; got != want {
+		t.Errorf("version output = %q, want %q", got, want)
+	}
+}
 
 const (
 	testStationID         = "FMT"


### PR DESCRIPTION
Summary

* Add a GoReleaser-based CLI release job to the release workflow
* Upload CLI archives and checksums alongside existing Wails GUI artifacts
* Update .goreleaser.yml to the GoReleaser v2 config format
* Limit GoReleaser to the cmd/radikron CLI artifact
* Pin release tooling to the project toolchain:
    * Go version from go.mod
    * Wails CLI v2.11.0
    * GoReleaser v2.16.0
* Remove GPG checksum signing for now, since release signing is not configured in CI

Validation

* goreleaser check
* goreleaser release --snapshot --clean --skip=publish
* git diff --check
* go test ./...
* go build -v ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now include CLI download artifacts alongside the existing app release assets.

* **Bug Fixes**
  * Improved release consistency by standardizing build versions and packaging settings.
  * Reduced the chance of incomplete or inconsistent release uploads.

* **Chores**
  * Updated release automation to use more deterministic dependency and build preparation steps.
  * Refined changelog filtering so documentation and test-only entries are excluded from release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->