### PR TITLE
fix(download): keep copied output when cleanup fails

### DIFF
--- a/download.go
+++ b/download.go
@@ -756,11 +756,11 @@ func moveFile(source, dest string) error {
 		return fmt.Errorf("failed to copy file: %w", err)
 	}
 
-	// Delete source file after successful copy
+	// Delete source file after successful copy. Once the destination has been
+	// written and closed, cleanup failure must not make the user-visible output
+	// look failed.
 	if err := os.Remove(source); err != nil {
-		// Clean up destination file if delete failed (atomic operation)
-		_ = os.Remove(dest)
-		return fmt.Errorf("failed to remove source file after copy: %w", err)
+		log.Printf("warning: failed to remove source file after copy: %v", err)
 	}
 
 	return nil

--- a/download_test.go
+++ b/download_test.go
@@ -712,6 +712,51 @@ func TestMoveFile_CopyFallback(t *testing.T) {
 	}
 }
 
+func TestMoveFile_CopyFallbackKeepsDestinationWhenSourceCleanupFails(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("Unix directory permissions are used to simulate source cleanup failure")
+	}
+
+	tmpDir := t.TempDir()
+	sourceDir := filepath.Join(tmpDir, "source")
+	destDir := filepath.Join(tmpDir, "dest")
+	if err := os.MkdirAll(sourceDir, DirPermissions); err != nil {
+		t.Fatalf("Failed to create source directory: %v", err)
+	}
+	if err := os.MkdirAll(destDir, DirPermissions); err != nil {
+		t.Fatalf("Failed to create dest directory: %v", err)
+	}
+
+	sourceFile := filepath.Join(sourceDir, "source.txt")
+	destFile := filepath.Join(destDir, "dest.txt")
+	testContent := "test content for cleanup failure"
+	if err := os.WriteFile(sourceFile, []byte(testContent), 0600); err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+	if err := os.Chmod(sourceDir, 0500); err != nil {
+		t.Fatalf("Failed to make source directory read-only: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(sourceDir, DirPermissions)
+	}()
+
+	err := moveFile(sourceFile, destFile)
+	if err != nil {
+		t.Fatalf("moveFile should keep copied destination when source cleanup fails: %v", err)
+	}
+
+	content, err := os.ReadFile(destFile)
+	if err != nil {
+		t.Fatalf("Failed to read destination file: %v", err)
+	}
+	if string(content) != testContent {
+		t.Errorf("File content mismatch: got %s, want %s", string(content), testContent)
+	}
+	if _, err := os.Stat(sourceFile); err != nil {
+		t.Errorf("Source file should remain when cleanup fails, got: %v", err)
+	}
+}
+
 func TestMoveFile_CopyFallbackErrorPaths(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- keep copied AAC output when fallback source cleanup fails
- log source cleanup failure as a warning after copy and close succeed
- add a regression test covering cleanup failure after copy fallback

## Root Cause

`moveFile` treated source removal failure after a successful copy as a failed move.
On Windows, a locked temp AAC source could make the download fail after the destination had already been written, then remove the valid destination.

## Impact

Downloads using a custom destination can now succeed when the output copy completed but temporary source cleanup is blocked.
The temporary source may remain until later temp-directory cleanup, but user output is preserved.

Closes #75

## Checks

- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file move reliability when source cleanup fails after a successful copy.
  * Destination files are now kept intact even if the original file can’t be removed.
  * Added coverage for a read-only source scenario to verify this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->